### PR TITLE
[libsocialcache] Use IdlePriority for worker threads

### DIFF
--- a/src/qml/abstractsocialcachemodel.cpp
+++ b/src/qml/abstractsocialcachemodel.cpp
@@ -96,7 +96,7 @@ void AbstractSocialCacheModelPrivate::updateRow(int row, const SocialCacheModelR
 void AbstractSocialCacheModelPrivate::initWorkerObject(AbstractWorkerObject *workerObjectToSet)
 {
     if (workerObjectToSet) {
-        m_workerThread.start(QThread::LowestPriority);
+        m_workerThread.start(QThread::IdlePriority);
         workerObject = workerObjectToSet;
         workerObject->moveToThread(&m_workerThread);
         connect(this, &AbstractSocialCacheModelPrivate::nodeIdentifierChanged,

--- a/src/qml/facebook/facebookimagedownloader.cpp
+++ b/src/qml/facebook/facebookimagedownloader.cpp
@@ -164,7 +164,7 @@ void FacebookImageDownloaderWorkerObject::slotImageDownloaded()
 FacebookImageDownloaderPrivate::FacebookImageDownloaderPrivate(FacebookImageDownloader *q)
     : QObject(), q_ptr(q), workerObject(new FacebookImageDownloaderWorkerObject())
 {
-    m_workerThread.start(QThread::LowestPriority);
+    m_workerThread.start(QThread::IdlePriority);
     workerObject->moveToThread(&m_workerThread);
 }
 


### PR DESCRIPTION
To avoid starving GUI threads of processing, we should use the IDLE
priority for all worker threads.
