### PR TITLE
[libsocialcache] Provide API to allow purging Posts

### DIFF
--- a/src/lib/abstractsocialpostcachedatabase.h
+++ b/src/lib/abstractsocialpostcachedatabase.h
@@ -28,20 +28,27 @@ class SocialPostImagePrivate;
 class SocialPostImage
 {
 public:
+
     enum ImageType {
         Invalid,
         Photo,
         Video
     };
+
     typedef QSharedPointer<SocialPostImage> Ptr;
     typedef QSharedPointer<const SocialPostImage> ConstPtr;
+
     explicit SocialPostImage();
     virtual ~SocialPostImage();
-    static SocialPostImage::Ptr create(const QString &url, ImageType type);
+
     QString url() const;
     ImageType type() const;
+
+    static SocialPostImage::Ptr create(const QString &url, ImageType type);
+
 protected:
     QScopedPointer<SocialPostImagePrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(SocialPostImage)
     explicit SocialPostImage(const QString &url, ImageType type);
@@ -53,12 +60,15 @@ class SocialPost
 public:
     typedef QSharedPointer<SocialPost> Ptr;
     typedef QSharedPointer<const SocialPost> ConstPtr;
+
     virtual ~SocialPost();
+
     static SocialPost::Ptr create(const QString &identifier, const QString &name,
                                   const QString &body, const QDateTime &timestamp,
                                   const QMap<int, SocialPostImage::ConstPtr> &images = QMap<int, SocialPostImage::ConstPtr>(),
                                   const QVariantMap &extra = QVariantMap(),
                                   const QList<int> &accounts = QList<int>());
+
     QString identifier() const;
     QString name() const;
     QString body() const;
@@ -71,8 +81,10 @@ public:
     void setExtra(const QVariantMap &extra);
     QList<int> accounts() const;
     void setAccounts(const QList<int> &accounts);
+
 protected:
     QScopedPointer<SocialPostPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(SocialPost)
     explicit SocialPost(const QString &identifier, const QString &name,
@@ -87,16 +99,23 @@ class AbstractSocialPostCacheDatabase: public AbstractSocialCacheDatabase
 {
 public:
     explicit AbstractSocialPostCacheDatabase();
+
     QList<SocialPost::ConstPtr> posts() const;
+
     void addPost(const QString &identifier, const QString &name,
                  const QString &body, const QDateTime &timestamp,
                  const QString &icon,
                  const QList<QPair<QString, SocialPostImage::ImageType> > &images,
                  const QVariantMap &extra, int account);
+
+    void removePosts(int accountId);
+
     bool write();
+
 protected:
     bool dbCreateTables();
     bool dbDropTables();
+
 private:
     Q_DECLARE_PRIVATE(AbstractSocialPostCacheDatabase)
 };

--- a/src/lib/facebookpostsdatabase.h
+++ b/src/lib/facebookpostsdatabase.h
@@ -27,6 +27,7 @@ class FacebookPostsDatabase: public AbstractSocialPostCacheDatabase
 public:
     explicit FacebookPostsDatabase();
     void initDatabase();
+
     void addFacebookPost(const QString &identifier, const QString &name, const QString &body,
                          const QDateTime &timestamp,
                          const QString &icon,
@@ -34,6 +35,7 @@ public:
                          const QString &attachmentName,  const QString &attachmentCaption,
                          const QString &attachmentDescription, bool allowLike, bool allowComment,
                          const QString &clientId, int account);
+
     static QString attachmentName(const SocialPost::ConstPtr &post);
     static QString attachmentCaption(const SocialPost::ConstPtr &post);
     static QString attachmentDescription(const SocialPost::ConstPtr &post);


### PR DESCRIPTION
This commit adds the removePosts(int accountId) function to the
posts database interface.  This allows clients to purge the local
database of posts for a given account.
