### PR TITLE
[libsocialcache] Improve locking and database cleanup

### DIFF
--- a/src/lib/abstractimagedownloader.cpp
+++ b/src/lib/abstractimagedownloader.cpp
@@ -17,7 +17,7 @@
  */
 
 #include "abstractimagedownloader.h"
-#include <QtCore/QDebug>
+
 #include <QtCore/QFileInfo>
 #include <QtCore/QDir>
 #include <QtCore/QCryptographicHash>
@@ -26,6 +26,8 @@
 #include <QtNetwork/QNetworkAccessManager>
 #include <QtNetwork/QNetworkReply>
 #include <QtNetwork/QNetworkRequest>
+
+#include <QtDebug>
 
 // The AbstractImageDownloader is a class used to build image downloader objects
 //
@@ -48,18 +50,24 @@ typedef QPair<QString, QVariantMap> ImageInfo;
 class AbstractImageDownloaderPrivate: public QObject
 {
     Q_OBJECT
+
 public:
     explicit AbstractImageDownloaderPrivate(AbstractImageDownloader *q);
     virtual ~AbstractImageDownloaderPrivate();
+
     void manageStack();
+
     QNetworkAccessManager *networkAccessManager;
     QMap<QNetworkReply *, ImageInfo> runningReplies;
     QList<ImageInfo> stack;
     int loadedCount;
+
 protected:
     AbstractImageDownloader * const q_ptr;
+
 private:
     Q_DECLARE_PUBLIC(AbstractImageDownloader)
+
 private Q_SLOTS:
     void slotFinished();
 };

--- a/src/lib/abstractimagedownloader.h
+++ b/src/lib/abstractimagedownloader.h
@@ -19,9 +19,10 @@
 #ifndef ABSTRACTIMAGEDOWNLOADER_H
 #define ABSTRACTIMAGEDOWNLOADER_H
 
+#include "socialsyncinterface.h"
+
 #include <QtCore/QObject>
 #include <QtCore/QVariantMap>
-#include "socialsyncinterface.h"
 
 class AbstractImageDownloaderPrivate;
 class AbstractImageDownloader : public QObject
@@ -30,10 +31,13 @@ class AbstractImageDownloader : public QObject
 public:
     explicit AbstractImageDownloader();
     virtual ~AbstractImageDownloader();
+
 public Q_SLOTS:
     void queue(const QString &url, const QVariantMap &data);
+
 Q_SIGNALS:
     void imageDownloaded(const QString &url, const QString &path);
+
 protected:
     static QString makeOutputFile(SocialSyncInterface::SocialNetwork socialNetwork,
                                   SocialSyncInterface::DataType dataType,
@@ -51,7 +55,13 @@ protected:
 
     // Write in the database
     virtual void dbWrite() = 0;
+
+    // Close the database.
+    // We must close the database prior to gracefully terminating the thread / destroying the worker object.
+    virtual bool dbClose() = 0;
+
     QScopedPointer<AbstractImageDownloaderPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(AbstractImageDownloader)
 };

--- a/src/lib/abstractsocialcachedatabase.h
+++ b/src/lib/abstractsocialcachedatabase.h
@@ -29,8 +29,12 @@ class AbstractSocialCacheDatabase
 public:
     explicit AbstractSocialCacheDatabase();
     virtual ~AbstractSocialCacheDatabase();
-    bool isValid() const;
+
+    // Whoever calls initDatabase() must also call closeDatabase().
     virtual void initDatabase() = 0;
+    bool closeDatabase();
+    bool isValid() const;
+
 protected:
     enum QueryMode {
         Insert,
@@ -38,19 +42,25 @@ protected:
         Update,
         Delete
     };
+
     explicit AbstractSocialCacheDatabase(AbstractSocialCacheDatabasePrivate &dd);
     void dbInit(const QString &serviceName, const QString &dataType,
                 const QString &dbFile, int userVersion);
+    bool dbClose();
+
     virtual bool dbCreateTables() = 0;
     virtual bool dbDropTables() = 0;
     bool dbCreatePragmaVersion(int version);
+
     bool dbBeginTransaction();
     bool dbWrite(const QString &table, const QStringList &keys,
                  const QMap<QString, QVariantList> &entries,
                  QueryMode mode = Insert, const QString &primary = QString());
     bool dbCommitTransaction();
     bool dbRollbackTransaction();
+
     QScopedPointer<AbstractSocialCacheDatabasePrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(AbstractSocialCacheDatabase)
 };

--- a/src/lib/abstractsocialcachedatabase_p.h
+++ b/src/lib/abstractsocialcachedatabase_p.h
@@ -31,19 +31,25 @@ class AbstractSocialCacheDatabasePrivate
 public:
     explicit AbstractSocialCacheDatabasePrivate(AbstractSocialCacheDatabase *q);
     virtual ~AbstractSocialCacheDatabasePrivate();
+
     QSqlDatabase db;
+
 protected:
     AbstractSocialCacheDatabase * const q_ptr;
+    ProcessMutex *mutex; // Process (and thread) mutex to prevent concurrent write
+
 private:
     int dbUserVersion(const QString &serviceName, const QString &dataType) const;
+
     bool doInsert(const QString &table, const QStringList &keys,
                   const QMap<QString, QVariantList> &entries,
                   bool replace = false);
     bool doUpdate(const QString &table, const QMap<QString, QVariantList> &entries,
                   const QString &primary);
     bool doDelete(const QString &table, const QString &key, const QVariantList &entries);
+
     bool valid; // Hold if the database has been correctly initialized
-    ProcessMutex *mutex; // Process mutex to prevent concurrent write
+
     Q_DECLARE_PUBLIC(AbstractSocialCacheDatabase)
 };
 

--- a/src/lib/facebookcalendardatabase.cpp
+++ b/src/lib/facebookcalendardatabase.cpp
@@ -19,10 +19,12 @@
 #include "facebookcalendardatabase.h"
 #include "abstractsocialcachedatabase_p.h"
 #include "socialsyncinterface.h"
-#include <QtCore/QtDebug>
+
 #include <QtCore/QStringList>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
+
+#include <QtDebug>
 
 static const char *DB_NAME = "facebook.db";
 static const int VERSION = 3;

--- a/src/lib/facebookcontactsdatabase.cpp
+++ b/src/lib/facebookcontactsdatabase.cpp
@@ -20,10 +20,12 @@
 #include "facebookcontactsdatabase.h"
 #include "abstractsocialcachedatabase_p.h"
 #include "socialsyncinterface.h"
-#include <QtCore/QtDebug>
+
 #include <QtCore/QStringList>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
+
+#include <QtDebug>
 
 static const char *DB_NAME = "facebook.db";
 static const int VERSION = 3;

--- a/src/lib/facebookimagesdatabase.h
+++ b/src/lib/facebookimagesdatabase.h
@@ -30,15 +30,20 @@ class FacebookUser
 public:
     typedef QSharedPointer<FacebookUser> Ptr;
     typedef QSharedPointer<const FacebookUser> ConstPtr;
+
     virtual ~FacebookUser();
+
     static FacebookUser::Ptr create(const QString &fbUserId, const QDateTime &updatedTime,
                                     const QString &userName, int count = -1);
+
     QString fbUserId() const;
     QDateTime updatedTime() const;
     QString userName() const;
     int count() const;
+
 protected:
     QScopedPointer<FacebookUserPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(FacebookUser)
     explicit FacebookUser(const QString &fbUserId, const QDateTime &updatedTime,
@@ -51,18 +56,23 @@ class FacebookAlbum
 public:
     typedef QSharedPointer<FacebookAlbum> Ptr;
     typedef QSharedPointer<const FacebookAlbum> ConstPtr;
+
     virtual ~FacebookAlbum();
+
     static FacebookAlbum::Ptr create(const QString &fbAlbumId, const QString &fbUserId,
                                      const QDateTime &createdTime, const QDateTime &updatedTime,
                                      const QString &albumName, int imageCount);
+
     QString fbAlbumId() const;
     QString fbUserId() const;
     QDateTime createdTime() const;
     QDateTime updatedTime() const;
     QString albumName() const;
     int imageCount() const;
+
 protected:
     QScopedPointer<FacebookAlbumPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(FacebookAlbum)
     explicit FacebookAlbum(const QString &fbAlbumId, const QString &fbUserId,
@@ -76,13 +86,16 @@ class FacebookImage
 public:
     typedef QSharedPointer<FacebookImage> Ptr;
     typedef QSharedPointer<const FacebookImage> ConstPtr;
+
     virtual ~FacebookImage();
+
     static FacebookImage::Ptr create(const QString & fbImageId, const QString & fbAlbumId,
                                      const QString & fbUserId, const QDateTime & createdTime,
                                      const QDateTime &updatedTime, const QString &imageName,
                                      int width, int height, const QString & thumbnailUrl,
                                      const QString & imageUrl, const QString & thumbnailFile,
                                      const QString & imageFile, int account = -1);
+
     QString fbImageId() const;
     QString fbAlbumId() const;
     QString fbUserId() const;
@@ -96,8 +109,10 @@ public:
     QString thumbnailFile() const;
     QString imageFile() const;
     int account() const;
+
 protected:
     QScopedPointer<FacebookImagePrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(FacebookImage)
     explicit FacebookImage(const QString & fbImageId, const QString & fbAlbumId,
@@ -162,6 +177,7 @@ public:
 protected:
     bool dbCreateTables();
     bool dbDropTables();
+
 private:
     Q_DECLARE_PRIVATE(FacebookImagesDatabase)
 };

--- a/src/lib/facebookpostsdatabase.cpp
+++ b/src/lib/facebookpostsdatabase.cpp
@@ -20,6 +20,8 @@
 #include "facebookpostsdatabase.h"
 #include "socialsyncinterface.h"
 
+#include <QtDebug>
+
 static const char *DB_NAME = "facebook.db";
 static const char *ATTACHMENT_NAME_KEY = "post_attachment_name";
 static const char *ATTACHMENT_CAPTION_KEY = "post_attachment_caption";
@@ -30,6 +32,10 @@ static const char *ALLOW_COMMENT_KEY = "allow_comment";
 
 FacebookPostsDatabase::FacebookPostsDatabase()
     : AbstractSocialPostCacheDatabase()
+{
+}
+
+FacebookPostsDatabase::~FacebookPostsDatabase()
 {
 }
 

--- a/src/lib/facebookpostsdatabase.h
+++ b/src/lib/facebookpostsdatabase.h
@@ -26,6 +26,8 @@ class FacebookPostsDatabase: public AbstractSocialPostCacheDatabase
 {
 public:
     explicit FacebookPostsDatabase();
+    ~FacebookPostsDatabase();
+
     void initDatabase();
 
     void addFacebookPost(const QString &identifier, const QString &name, const QString &body,

--- a/src/lib/semaphore_p.h
+++ b/src/lib/semaphore_p.h
@@ -34,6 +34,7 @@
 #define SEMAPHORE_P_H
 
 #include <QString>
+#include <QMutex>
 
 class Semaphore
 {
@@ -57,12 +58,12 @@ private:
 class ProcessMutex
 {
     Semaphore m_semaphore;
+    QMutex m_mutex;
 
 public:
     ProcessMutex(const QString &path);
     bool lock();
     bool unlock();
-    bool isLocked() const;
 };
 
 

--- a/src/lib/socialnetworksyncdatabase.cpp
+++ b/src/lib/socialnetworksyncdatabase.cpp
@@ -19,12 +19,13 @@
 #include "socialnetworksyncdatabase.h"
 #include "abstractsocialcachedatabase_p.h"
 
-#include <QtCore/QDebug>
 #include <QtCore/QStringList>
 #include <QtCore/QVariantList>
 #include <QtCore/QMap>
 #include <QtSql/QSqlQuery>
 #include <QtSql/QSqlError>
+
+#include <QtDebug>
 
 static const char *SERVICE_NAME = "Sync";
 static const char *DATA_TYPE = "Sync";
@@ -186,7 +187,6 @@ bool SocialNetworkSyncDatabase::dbCreateTables()
                   "CONSTRAINT id PRIMARY KEY (accountId, serviceName, dataType))");
     if (!query.exec()) {
         qWarning() << "Unable to create syncTimestamps table" << query.lastError().text();
-        d->db.close();
         return false;
     }
 

--- a/src/lib/twitterpostsdatabase.cpp
+++ b/src/lib/twitterpostsdatabase.cpp
@@ -20,6 +20,8 @@
 #include "twitterpostsdatabase.h"
 #include "socialsyncinterface.h"
 
+#include <QtDebug>
+
 static const char *DB_NAME = "twitter.db";
 static const char *SCREEN_NAME_KEY = "screen_name";
 static const char *RETWEETER_KEY = "retweeter";
@@ -28,6 +30,10 @@ static const char *CONSUMER_SECRET_KEY = "consumer_secret";
 
 TwitterPostsDatabase::TwitterPostsDatabase()
     : AbstractSocialPostCacheDatabase()
+{
+}
+
+TwitterPostsDatabase::~TwitterPostsDatabase()
 {
 }
 

--- a/src/lib/twitterpostsdatabase.h
+++ b/src/lib/twitterpostsdatabase.h
@@ -26,7 +26,10 @@ class TwitterPostsDatabase: public AbstractSocialPostCacheDatabase
 {
 public:
     explicit TwitterPostsDatabase();
+    ~TwitterPostsDatabase();
+
     void initDatabase();
+
     void addTwitterPost(const QString &identifier, const QString &name, const QString &body,
                         const QDateTime &timestamp,
                         const QString &icon,
@@ -34,6 +37,7 @@ public:
                         const QString &screenName, const QString &retweeter,
                         const QString &consumerKey, const QString &consumerSecret,
                         int account);
+
     static QString screenName(const SocialPost::ConstPtr &post);
     static QString retweeter(const SocialPost::ConstPtr &post);
     static QString consumerKey(const SocialPost::ConstPtr &post);

--- a/src/qml/abstractsocialcachemodel.h
+++ b/src/qml/abstractsocialcachemodel.h
@@ -32,8 +32,10 @@ class AbstractSocialCacheModel : public QAbstractListModel
     Q_PROPERTY(QString nodeIdentifier READ nodeIdentifier WRITE setNodeIdentifier
                NOTIFY nodeIdentifierChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+
 public:
     virtual ~AbstractSocialCacheModel();
+
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     QVariant data(const QModelIndex &index, int role) const;
     Q_INVOKABLE QVariant getField(int row, int role) const;
@@ -46,14 +48,18 @@ public:
     // Methods used to update the model in the C++ side
     void updateData(const SocialCacheModelData &data);
     void updateRow(int row, const SocialCacheModelRow &data);
+
 public Q_SLOTS:
     void refresh();
+
 Q_SIGNALS:
     void nodeIdentifierChanged();
     void countChanged();
+
 protected:
     explicit AbstractSocialCacheModel(AbstractSocialCacheModelPrivate &dd, QObject *parent = 0);
     QScopedPointer<AbstractSocialCacheModelPrivate> d_ptr;
+
 private:
     Q_DECLARE_PRIVATE(AbstractSocialCacheModel)
 };

--- a/src/qml/facebook/facebookimagecachemodel.h
+++ b/src/qml/facebook/facebookimagecachemodel.h
@@ -31,8 +31,10 @@ class FacebookImageCacheModel: public AbstractSocialCacheModel
                NOTIFY typeChanged)
     Q_PROPERTY(FacebookImageDownloader * downloader READ downloader WRITE setDownloader
                NOTIFY downloaderChanged)
+
     Q_ENUMS(FacebookGalleryRole)
     Q_ENUMS(ModelDataType)
+
 public:
     enum FacebookGalleryRole {
         FacebookId = 0,
@@ -62,17 +64,18 @@ public:
     FacebookImageCacheModel::ModelDataType type() const;
     void setType(FacebookImageCacheModel::ModelDataType type);
 
-    FacebookImageDownloader * downloader() const;
+    FacebookImageDownloader *downloader() const;
     void setDownloader(FacebookImageDownloader *downloader);
 
 public Q_SLOTS:
     void loadImages();
+
 Q_SIGNALS:
     void typeChanged();
     void downloaderChanged();
+
 private:
     Q_DECLARE_PRIVATE(FacebookImageCacheModel)
-
 };
 
 #endif // FACEBOOKIMAGECACHEMODEL_H

--- a/src/qml/facebook/facebookpostsmodel.cpp
+++ b/src/qml/facebook/facebookpostsmodel.cpp
@@ -26,9 +26,14 @@
 class FacebookPostsWorkerObject: public AbstractWorkerObject
 {
     Q_OBJECT
+
 public:
     explicit FacebookPostsWorkerObject();
+    ~FacebookPostsWorkerObject();
+
     void refresh();
+    void finalCleanup();
+
 private:
     FacebookPostsDatabase m_db;
     bool m_enabled;
@@ -37,6 +42,15 @@ private:
 FacebookPostsWorkerObject::FacebookPostsWorkerObject()
     : AbstractWorkerObject(), m_enabled(false)
 {
+}
+
+FacebookPostsWorkerObject::~FacebookPostsWorkerObject()
+{
+}
+
+void FacebookPostsWorkerObject::finalCleanup()
+{
+    m_db.closeDatabase();
 }
 
 void FacebookPostsWorkerObject::refresh()
@@ -87,6 +101,7 @@ class FacebookPostsModelPrivate: public AbstractSocialCacheModelPrivate
 {
 public:
     explicit FacebookPostsModelPrivate(FacebookPostsModel *q);
+
 private:
     Q_DECLARE_PUBLIC(FacebookPostsModel)
 };

--- a/src/qml/twitter/twitterpostsmodel.cpp
+++ b/src/qml/twitter/twitterpostsmodel.cpp
@@ -26,9 +26,14 @@
 class TwitterPostsWorkerObject: public AbstractWorkerObject
 {
     Q_OBJECT
+
 public:
     explicit TwitterPostsWorkerObject();
+    ~TwitterPostsWorkerObject();
+
     void refresh();
+    void finalCleanup();
+
 private:
     TwitterPostsDatabase m_db;
     bool m_enabled;
@@ -37,6 +42,15 @@ private:
 TwitterPostsWorkerObject::TwitterPostsWorkerObject()
     : AbstractWorkerObject(), m_enabled(false)
 {
+}
+
+TwitterPostsWorkerObject::~TwitterPostsWorkerObject()
+{
+}
+
+void TwitterPostsWorkerObject::finalCleanup()
+{
+    m_db.closeDatabase();
 }
 
 void TwitterPostsWorkerObject::refresh()

--- a/tests/tst_abstractsocialcachedatabase/main.cpp
+++ b/tests/tst_abstractsocialcachedatabase/main.cpp
@@ -327,7 +327,6 @@ protected:
                        "id INTEGER UNIQUE PRIMARY KEY AUTOINCREMENT,"
                        "value TEXT)");
         if (!query.exec()) {
-            d->db.close();
             return false;
         }
 
@@ -335,7 +334,6 @@ protected:
                        "id INTEGER UNIQUE PRIMARY KEY AUTOINCREMENT,"
                        "value TEXT)");
         if (!query.exec()) {
-            d->db.close();
             return false;
         }
 
@@ -344,7 +342,6 @@ protected:
                        "albumId INTEGER,"
                        "value TEXT)");
         if (!query.exec()) {
-            d->db.close();
             return false;
         }
 
@@ -361,19 +358,16 @@ protected:
         QSqlQuery query(d->db);
         query.prepare("DROP TABLE IF EXISTS tests");
         if (!query.exec()) {
-            d->db.close();
             return false;
         }
 
         query.prepare("DROP TABLE IF EXISTS albums");
         if (!query.exec()) {
-            d->db.close();
             return false;
         }
 
         query.prepare("DROP TABLE IF EXISTS photos");
         if (!query.exec()) {
-            d->db.close();
             return false;
         }
 


### PR DESCRIPTION
This commit adds more locking around sensitive code areas, and also
ensures that each derived type is responsible for closing the database
at the appropriate time (depending on the threading being used).
