### PR TITLE
[bugfix] Fixed an issue that generated potential wrong SQL queries

### DIFF
--- a/src/lib/abstractsocialcachedatabase.cpp
+++ b/src/lib/abstractsocialcachedatabase.cpp
@@ -136,6 +136,10 @@ bool AbstractSocialCacheDatabasePrivate::doUpdate(const QString &table,
         }
     }
 
+    if (otherEntries.isEmpty()) {
+        return true;
+    }
+
     QString queryString = QLatin1String("UPDATE ");
     queryString.append(table);
     queryString.append(QLatin1String(" SET "));


### PR DESCRIPTION
This commit prevents the other keys to be empty during an
UPDATE query.
