### PR TITLE
[bugfix] Makes libsocialcache to build

### DIFF
--- a/src/lib/abstractimagedownloader.cpp
+++ b/src/lib/abstractimagedownloader.cpp
@@ -199,8 +199,5 @@ void AbstractImageDownloader::dbWrite()
 
 bool AbstractImageDownloader::dbClose()
 {
+    return true;
 }
-
-
-
-#include "abstractimagedownloader.moc"


### PR DESCRIPTION
This commit fixes a warning in abstract image
downloader, and also makes libsocialcache build
again, by removing a deprecated moc include.
