### PR TITLE
[libsocialcache] Make thread management an internal detail of databases.

### DIFF
--- a/rpm/libsocialcache.spec
+++ b/rpm/libsocialcache.spec
@@ -1,6 +1,6 @@
 Name:       libsocialcache
 Summary:    A library that manages data from social networks
-Version:    0.0.13
+Version:    0.0.14
 Release:    1
 Group:      Applications/Multimedia
 License:    LGPLv2.1
@@ -49,6 +49,15 @@ Group:     Applications/Multimedia
 %description qml-plugin
 This package contains the qml plugin for socialcache
 
+%package tests
+Summary:    Unit tests for libsocialcache
+Group:      System/Libraries
+BuildRequires:  pkgconfig(Qt5Test)
+Requires:   %{name} = %{version}-%{release}
+
+%description tests
+This package contains unit tests for the libsocialcache library.
+
 %prep
 %setup -q -n %{name}-%{version}
 
@@ -81,3 +90,7 @@ rm -rf %{buildroot}
 %{_libdir}/qt5/qml/org/nemomobile/socialcache/qmldir
 %{_libdir}/qt5/qml/org/nemomobile/socialcache/libsocialcacheqml.so
 %{_datadir}/translations/socialcache_eng_en.qm
+
+%files tests
+%defattr(-,root,root,-)
+/opt/tests/libsocialcache/*

--- a/src/lib/abstractimagedownloader.h
+++ b/src/lib/abstractimagedownloader.h
@@ -30,7 +30,7 @@ class AbstractImageDownloader : public QObject
 {
     Q_OBJECT
 public:
-    explicit AbstractImageDownloader();
+    AbstractImageDownloader(QObject *parent = 0);
     virtual ~AbstractImageDownloader();
 
 public Q_SLOTS:
@@ -40,6 +40,8 @@ Q_SIGNALS:
     void imageDownloaded(const QString &url, const QString &path, const QVariantMap &metadata);
 
 protected:
+    explicit AbstractImageDownloader(AbstractImageDownloaderPrivate &dd, QObject *parent);
+
     static QString makeOutputFile(SocialSyncInterface::SocialNetwork socialNetwork,
                                   SocialSyncInterface::DataType dataType,
                                   const QString &identifier);
@@ -60,11 +62,11 @@ protected:
     // Write in the database
     virtual void dbWrite();
 
-    // Close the database.
-    // We must close the database prior to gracefully terminating the thread / destroying the worker object.
-    virtual bool dbClose();
-
     QScopedPointer<AbstractImageDownloaderPrivate> d_ptr;
+
+private Q_SLOTS:
+    void readyRead();
+    void slotFinished();
 
 private:
     Q_DECLARE_PRIVATE(AbstractImageDownloader)

--- a/src/lib/abstractimagedownloader_p.h
+++ b/src/lib/abstractimagedownloader_p.h
@@ -50,10 +50,8 @@ struct ImageInfo
 
 
 class AbstractImageDownloader;
-class AbstractImageDownloaderPrivate: public QObject
+class AbstractImageDownloaderPrivate
 {
-    Q_OBJECT
-
 public:
     explicit AbstractImageDownloaderPrivate(AbstractImageDownloader *q);
     virtual ~AbstractImageDownloaderPrivate();
@@ -67,10 +65,6 @@ private:
     QList<ImageInfo *> stack;
     int loadedCount;
     Q_DECLARE_PUBLIC(AbstractImageDownloader)
-
-private Q_SLOTS:
-    void readyRead();
-    void slotFinished();
 };
 
 #endif // ABSTRACTIMAGEDOWNLOADER_P_H

--- a/src/lib/abstractsocialpostcachedatabase.h
+++ b/src/lib/abstractsocialpostcachedatabase.h
@@ -97,8 +97,11 @@ private:
 class AbstractSocialPostCacheDatabasePrivate;
 class AbstractSocialPostCacheDatabase: public AbstractSocialCacheDatabase
 {
+    Q_OBJECT
 public:
-    explicit AbstractSocialPostCacheDatabase();
+    explicit AbstractSocialPostCacheDatabase(
+            const QString &serviceName, const QString &databaseFile);
+    ~AbstractSocialPostCacheDatabase();
 
     QList<SocialPost::ConstPtr> posts() const;
 
@@ -110,16 +113,24 @@ public:
 
     void removePosts(int accountId);
 
-    bool write();
+    void commit();
+    void refresh();
+
+Q_SIGNALS:
+    void postsChanged();
 
 protected:
-    bool dbCreateTables();
-    bool dbDropTables();
+    bool read();
+    bool write();
+    bool createTables(QSqlDatabase database) const;
+    bool dropTables(QSqlDatabase database) const;
+
+    void readFinished();
+
 
 private:
     Q_DECLARE_PRIVATE(AbstractSocialPostCacheDatabase)
 };
 
-static const int POST_DB_VERSION = 1;
 
 #endif // ABSTRACTSOCIALPOSTCACHEDATABASE_H

--- a/src/lib/facebookcalendardatabase.h
+++ b/src/lib/facebookcalendardatabase.h
@@ -48,16 +48,18 @@ public:
     explicit FacebookCalendarDatabase();
     ~FacebookCalendarDatabase();
 
-    void initDatabase();
-    bool removeEvents(int accountId);
+    void removeEvents(int accountId);
 
     QList<FacebookEvent::ConstPtr> events(int accountId);
     void addSyncedEvent(const QString &fbEventId, int accountId, const QString &incidenceId);
 
-    bool sync(int accountId);
+    void sync(int accountId);
+
 protected:
-    bool dbCreateTables();
-    bool dbDropTables();
+    bool write();
+    bool createTables(QSqlDatabase database) const;
+    bool dropTables(QSqlDatabase database) const;
+
 private:
     Q_DECLARE_PRIVATE(FacebookCalendarDatabase)
 };

--- a/src/lib/facebookcontactsdatabase.h
+++ b/src/lib/facebookcontactsdatabase.h
@@ -54,7 +54,6 @@ class FacebookContactsDatabase: public AbstractSocialCacheDatabase
 public:
     explicit FacebookContactsDatabase();
     ~FacebookContactsDatabase();
-    void initDatabase();
 
     bool removeContacts(int accountId);
     bool removeContacts(const QStringList &fbFriendIds);
@@ -66,10 +65,14 @@ public:
                           const QString &coverUrl);
     void updatePictureFile(const QString &fbFriendId, const QString &pictureFile);
     void updateCoverFile(const QString &fbFriendId, const QString &coverFile);
-    bool write();
+
+    void commit();
+
 protected:
-    bool dbCreateTables();
-    bool dbDropTables();
+    bool write();
+    bool createTables(QSqlDatabase database) const;
+    bool dropTables(QSqlDatabase database) const;
+
 private:
     Q_DECLARE_PRIVATE(FacebookContactsDatabase)
 };

--- a/src/lib/facebookimagesdatabase.h
+++ b/src/lib/facebookimagesdatabase.h
@@ -130,11 +130,10 @@ bool operator==(const FacebookImage::ConstPtr &image1, const FacebookImage::Cons
 class FacebookImagesDatabasePrivate;
 class FacebookImagesDatabase: public AbstractSocialCacheDatabase
 {
+    Q_OBJECT
 public:
     explicit FacebookImagesDatabase();
     ~FacebookImagesDatabase();
-
-    void initDatabase();
 
     // Account manipulation
     bool syncAccount(int accountId, const QString &fbUserId);
@@ -145,7 +144,6 @@ public:
     void addUser(const QString &fbUserId, const QDateTime &updatedTime,
                  const QString &userName);
     void removeUser(const QString &fbUserId);
-    QList<FacebookUser::ConstPtr> users() const;
 
     // Album cache manipulation
     QStringList allAlbumIds(bool *ok = 0) const;
@@ -154,7 +152,6 @@ public:
                   const QDateTime &updatedTime, const QString &albumName, int imageCount);
     void removeAlbum(const QString &fbAlbumId);
     void removeAlbums(const QStringList &fbAlbumIds);
-    QList<FacebookAlbum::ConstPtr> albums(const QString &fbUserId = QString());
 
     // Images cache manipulation
     QStringList allImageIds(bool *ok = 0) const;
@@ -169,14 +166,29 @@ public:
     void updateImageFile(const QString &fbImageId, const QString &imageFile);
     void removeImage(const QString &fbImageId);
     void removeImages(const QStringList &fbImageIds);
-    QList<FacebookImage::ConstPtr> userImages(const QString &fbUserId = QString());
-    QList<FacebookImage::ConstPtr> albumImages(const QString &fbAlbumId);
 
-    bool write();
+    void commit();
+
+    QList<FacebookUser::ConstPtr> users() const;
+    QList<FacebookImage::ConstPtr> images() const;
+    QList<FacebookAlbum::ConstPtr> albums() const;
+
+    void queryUsers();
+    void queryAlbums(const QString &userId = QString());
+    void queryUserImages(const QString &userId = QString());
+    void queryAlbumImages(const QString &albumId);
+
+Q_SIGNALS:
+    void queryFinished();
 
 protected:
-    bool dbCreateTables();
-    bool dbDropTables();
+    bool read();
+    void readFinished();
+
+    bool write();
+    bool createTables(QSqlDatabase database) const;
+    bool dropTables(QSqlDatabase database) const;
+
 
 private:
     Q_DECLARE_PRIVATE(FacebookImagesDatabase)

--- a/src/lib/facebookpostsdatabase.cpp
+++ b/src/lib/facebookpostsdatabase.cpp
@@ -32,19 +32,14 @@ static const char *ALLOW_LIKE_KEY = "allow_like";
 static const char *ALLOW_COMMENT_KEY = "allow_comment";
 
 FacebookPostsDatabase::FacebookPostsDatabase()
-    : AbstractSocialPostCacheDatabase()
+    : AbstractSocialPostCacheDatabase(
+          SocialSyncInterface::socialNetwork(SocialSyncInterface::Facebook),
+          QLatin1String(DB_NAME))
 {
 }
 
 FacebookPostsDatabase::~FacebookPostsDatabase()
 {
-}
-
-void FacebookPostsDatabase::initDatabase()
-{
-    dbInit(SocialSyncInterface::socialNetwork(SocialSyncInterface::Facebook),
-           SocialSyncInterface::dataType(SocialSyncInterface::Posts),
-           QLatin1String(DB_NAME), POST_DB_VERSION);
 }
 
 void FacebookPostsDatabase::addFacebookPost(const QString &identifier, const QString &name,

--- a/src/lib/facebookpostsdatabase.h
+++ b/src/lib/facebookpostsdatabase.h
@@ -28,8 +28,6 @@ public:
     explicit FacebookPostsDatabase();
     ~FacebookPostsDatabase();
 
-    void initDatabase();
-
     void addFacebookPost(const QString &identifier, const QString &name, const QString &body,
                          const QDateTime &timestamp,
                          const QString &icon,

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -3,7 +3,7 @@ include(../../common.pri)
 TEMPLATE = lib
 CONFIG += qt create_prl no_install_prl create_pc
 QT += sql
-VERSION = 0.0.12
+VERSION = 0.0.14
 
 isEmpty(PREFIX) {
     PREFIX=/usr

--- a/src/lib/socialnetworksyncdatabase.h
+++ b/src/lib/socialnetworksyncdatabase.h
@@ -28,16 +28,20 @@ class SocialNetworkSyncDatabase: public AbstractSocialCacheDatabase
 {
 public:
     explicit SocialNetworkSyncDatabase();
-    void initDatabase();
+    ~SocialNetworkSyncDatabase();
+
     QList<int> syncedAccounts(const QString &serviceName, const QString &dataType) const;
     QDateTime lastSyncTimestamp(const QString &serviceName, const QString &dataType,
                                 int accountId) const;
     void addSyncTimestamp(const QString &serviceName, const QString &dataType,
                           int accountId, const QDateTime &timestamp);
-    bool write();
+    void commit();
+
 protected:
-    bool dbCreateTables();
-    bool dbDropTables();
+    bool write();
+    bool createTables(QSqlDatabase database) const;
+    bool dropTables(QSqlDatabase database) const;
+
 private:
     Q_DECLARE_PRIVATE(SocialNetworkSyncDatabase)
 };

--- a/src/lib/twitterpostsdatabase.cpp
+++ b/src/lib/twitterpostsdatabase.cpp
@@ -29,19 +29,14 @@ static const char *CONSUMER_KEY_KEY = "consumer_key";
 static const char *CONSUMER_SECRET_KEY = "consumer_secret";
 
 TwitterPostsDatabase::TwitterPostsDatabase()
-    : AbstractSocialPostCacheDatabase()
+    : AbstractSocialPostCacheDatabase(
+          SocialSyncInterface::socialNetwork(SocialSyncInterface::Twitter),
+          QLatin1String(DB_NAME))
 {
 }
 
 TwitterPostsDatabase::~TwitterPostsDatabase()
 {
-}
-
-void TwitterPostsDatabase::initDatabase()
-{
-    dbInit(SocialSyncInterface::socialNetwork(SocialSyncInterface::Twitter),
-           SocialSyncInterface::dataType(SocialSyncInterface::Posts),
-           QLatin1String(DB_NAME), POST_DB_VERSION);
 }
 
 void TwitterPostsDatabase::addTwitterPost(const QString &identifier, const QString &name,

--- a/src/lib/twitterpostsdatabase.h
+++ b/src/lib/twitterpostsdatabase.h
@@ -28,8 +28,6 @@ public:
     explicit TwitterPostsDatabase();
     ~TwitterPostsDatabase();
 
-    void initDatabase();
-
     void addTwitterPost(const QString &identifier, const QString &name, const QString &body,
                         const QDateTime &timestamp,
                         const QString &icon,

--- a/src/qml/abstractsocialcachemodel.cpp
+++ b/src/qml/abstractsocialcachemodel.cpp
@@ -44,69 +44,13 @@ int updateRange<AbstractSocialCacheModelPrivate, SocialCacheModelData>(
     return count;
 }
 
-AbstractWorkerObject::AbstractWorkerObject():
-    m_loading(false)
-{
-}
-
-AbstractWorkerObject::~AbstractWorkerObject()
-{
-}
-
-bool AbstractWorkerObject::isLoading() const
-{
-    return m_loading;
-}
-
-void AbstractWorkerObject::triggerRefresh()
-{
-    if (!isLoading()) {
-        refresh();
-    }
-}
-
-void AbstractWorkerObject::setNodeIdentifier(const QString &nodeIdentifierToSet)
-{
-    nodeIdentifier = nodeIdentifierToSet;
-}
-
-void AbstractWorkerObject::setLoading(bool loading)
-{
-    QMutexLocker locker(&m_mutex);
-    Q_UNUSED(locker)
-    m_loading = loading;
-}
-
-void AbstractWorkerObject::quitGracefully()
-{
-    m_quitMutex.lock();
-    finalCleanup();
-    m_quitWC.wakeAll();
-    m_quitMutex.unlock();
-}
-
-AbstractSocialCacheModelPrivate::AbstractSocialCacheModelPrivate(AbstractSocialCacheModel *q,
-                                                                 QObject *parent)
-    :  QObject(parent), m_workerObject(0), q_ptr(q)
+AbstractSocialCacheModelPrivate::AbstractSocialCacheModelPrivate(AbstractSocialCacheModel *q)
+    : q_ptr(q)
 {
 }
 
 AbstractSocialCacheModelPrivate::~AbstractSocialCacheModelPrivate()
 {
-    if (m_workerThread.isRunning()) {
-        // tell worker object to quit gracefully.
-        m_workerObject->m_quitMutex.lock();
-        QMetaObject::invokeMethod(m_workerObject, "quitGracefully", Qt::QueuedConnection);
-        m_workerObject->m_quitWC.wait(&m_workerObject->m_quitMutex);
-        m_workerObject->m_quitMutex.unlock();
-
-        // now terminate the thread
-        m_workerThread.quit();
-        m_workerThread.wait();
-    }
-
-    // and delete the worker object - this will ensure the database gets closed.
-    delete m_workerObject;
 }
 
 void AbstractSocialCacheModelPrivate::clearData()
@@ -129,24 +73,6 @@ void AbstractSocialCacheModelPrivate::updateRow(int row, const SocialCacheModelR
 {
     Q_Q(AbstractSocialCacheModel);
     q->updateRow(row, data);
-}
-
-void AbstractSocialCacheModelPrivate::initWorkerObject(AbstractWorkerObject *workerObjectToSet)
-{
-    if (workerObjectToSet) {
-        m_workerThread.start(QThread::IdlePriority);
-        m_workerObject = workerObjectToSet;
-        m_workerObject->moveToThread(&m_workerThread);
-        connect(this, &AbstractSocialCacheModelPrivate::nodeIdentifierChanged,
-                m_workerObject, &AbstractWorkerObject::setNodeIdentifier);
-        connect(this, &AbstractSocialCacheModelPrivate::refreshRequested,
-                m_workerObject, &AbstractWorkerObject::triggerRefresh);
-        connect(m_workerObject, &AbstractWorkerObject::dataUpdated,
-                this, &AbstractSocialCacheModelPrivate::updateData);
-        connect(m_workerObject, &AbstractWorkerObject::rowUpdated,
-                this, &AbstractSocialCacheModelPrivate::updateRow);
-    }
-
 }
 
 void AbstractSocialCacheModelPrivate::insertRange(
@@ -225,7 +151,7 @@ void AbstractSocialCacheModel::setNodeIdentifier(const QString &nodeIdentifier)
     if (d->nodeIdentifier != nodeIdentifier) {
         d->nodeIdentifier = nodeIdentifier;
         emit nodeIdentifierChanged();
-        emit d->nodeIdentifierChanged(nodeIdentifier);
+        d->nodeIdentifierChanged();
     }
 }
 
@@ -255,10 +181,4 @@ void AbstractSocialCacheModel::updateRow(int row, const SocialCacheModelRow &dat
         d->m_data[row].insert(key, data.value(key));
     }
     emit dataChanged(index(row), index(row));
-}
-
-void AbstractSocialCacheModel::refresh()
-{
-    Q_D(AbstractSocialCacheModel);
-    emit d->refreshRequested();
 }

--- a/src/qml/abstractsocialcachemodel.h
+++ b/src/qml/abstractsocialcachemodel.h
@@ -45,12 +45,9 @@ public:
     void setNodeIdentifier(const QString &nodeIdentifier);
     int count() const;
 
-    // Methods used to update the model in the C++ side
-    void updateData(const SocialCacheModelData &data);
-    void updateRow(int row, const SocialCacheModelRow &data);
 
 public Q_SLOTS:
-    void refresh();
+    virtual void refresh() = 0;
 
 Q_SIGNALS:
     void nodeIdentifierChanged();
@@ -58,6 +55,11 @@ Q_SIGNALS:
     void modelUpdated();
 
 protected:
+
+    // Methods used to update the model in the C++ side
+    void updateData(const SocialCacheModelData &data);
+    void updateRow(int row, const SocialCacheModelRow &data);
+
     explicit AbstractSocialCacheModel(AbstractSocialCacheModelPrivate &dd, QObject *parent = 0);
     QScopedPointer<AbstractSocialCacheModelPrivate> d_ptr;
 

--- a/src/qml/abstractsocialcachemodel_p.h
+++ b/src/qml/abstractsocialcachemodel_p.h
@@ -22,55 +22,10 @@
 
 #include "abstractsocialcachemodel.h"
 
-#include <QtCore/QThread>
-#include <QtCore/QMutex>
-#include <QtCore/QWaitCondition>
+#include <QtCore/QMap>
 
-class AbstractSocialCacheModel;
-class AbstractSocialCacheModelPrivate;
-class AbstractWorkerObject: public QObject
+class AbstractSocialCacheModelPrivate
 {
-    Q_OBJECT
-
-public:
-    explicit AbstractWorkerObject();
-    virtual ~AbstractWorkerObject();
-    bool isLoading() const;
-
-public Q_SLOTS:
-    // Slots are used by the model to set properties
-    // or trigger task for the object
-    void triggerRefresh();
-    void setNodeIdentifier(const QString &nodeIdentifierToSet);
-
-Q_SIGNALS:
-    // Signals are used to signal the model
-    // that new data arrived
-    void dataUpdated(const SocialCacheModelData &data);
-    void rowUpdated(int row, const SocialCacheModelRow &data);
-
-protected:
-    QString nodeIdentifier; // Matches the node identifier in ASCMP
-    void setLoading(bool loading);
-    // Reimplement to perform model refreshing operation
-    virtual void refresh() = 0;
-
-public Q_SLOTS:
-    void quitGracefully();
-public:
-    virtual void finalCleanup() = 0;
-    QMutex m_quitMutex;
-    QWaitCondition m_quitWC;
-
-private:
-    bool m_loading;
-    QMutex m_mutex;
-};
-
-class AbstractSocialCacheModelPrivate: public QObject
-{
-    Q_OBJECT
-
 public:
     virtual ~AbstractSocialCacheModelPrivate();
     QString nodeIdentifier;
@@ -79,28 +34,19 @@ public:
     void updateRange(int index, int count, const SocialCacheModelData &source, int sourceIndex);
     void removeRange(int index, int count);
 
-public Q_SLOTS:
     void clearData();
     void updateData(const SocialCacheModelData &data);
     void updateRow(int row, const SocialCacheModelRow &data);
 
-Q_SIGNALS:
-    void nodeIdentifierChanged(const QString &nodeIdentifier);
-    void refreshRequested();
+    QList<QMap<int, QVariant> > m_data;
 
 protected:
-    explicit AbstractSocialCacheModelPrivate(AbstractSocialCacheModel *q,
-                                             QObject *parent = 0);
-    // Prepare the worker object by establishing connections
-    // implement if needed. Only call it in class constructor,
-    // as it is unsafe to call it in private class
-    // constructors.
-    virtual void initWorkerObject(AbstractWorkerObject *workerObjectToSet);
-    QList<QMap<int, QVariant> > m_data;
-    AbstractWorkerObject *m_workerObject;
+    explicit AbstractSocialCacheModelPrivate(AbstractSocialCacheModel *q);
+
+    virtual void nodeIdentifierChanged() {}
+
     AbstractSocialCacheModel * const q_ptr;
 private:
-    QThread m_workerThread;
     Q_DECLARE_PUBLIC(AbstractSocialCacheModel)
 };
 

--- a/src/qml/facebook/facebookimagecachemodel.cpp
+++ b/src/qml/facebook/facebookimagecachemodel.cpp
@@ -44,286 +44,51 @@ static const char *ROW_KEY = "row";
 
 #define SOCIALCACHE_FACEBOOK_IMAGE_DIR   PRIVILEGED_DATA_DIR + QLatin1String("/Images/")
 
-struct FacebookImageWorkerImageData;
-class FacebookImageWorkerObject: public AbstractWorkerObject, private FacebookImagesDatabase
+class FacebookImageCacheModelPrivate : public AbstractSocialCacheModelPrivate
 {
-    Q_OBJECT
-
 public:
-    explicit FacebookImageWorkerObject();
-    ~FacebookImageWorkerObject();
+    FacebookImageCacheModelPrivate(FacebookImageCacheModel *q);
 
-    void refresh();
-    void finalCleanup();
+    void queue(
+            int row,
+            FacebookImageDownloader::ImageType imageType,
+            const QString &identifier,
+            const QString &url);
 
-public Q_SLOTS:
-    void setType(int typeToSet);
-    void queueImages();
-    void queueImageThumbnail(int row, const FacebookImage::ConstPtr &image);
-    void queueImageFull(int row, const FacebookImage::ConstPtr &image);
-
-Q_SIGNALS:
-    void requestQueue(const QString &url, const QVariantMap &metadata);
-
-protected:
-    FacebookImageCacheModel::ModelDataType type;
-
-private:
-    void queue(int row,
-               FacebookImageDownloaderWorkerObject::ImageType imageType, const QString &identifier,
-               const QString &url);
-
-    bool m_enabled;
-    QList<QPair<FacebookImage::ConstPtr, int> > m_fullImages;
-};
-
-class FacebookImageCacheModelPrivate: public AbstractSocialCacheModelPrivate
-{
-    Q_OBJECT
-
-public:
-    explicit FacebookImageCacheModelPrivate(FacebookImageCacheModel *q);
-    FacebookImageCacheModel::ModelDataType type;
     FacebookImageDownloader *downloader;
+    FacebookImagesDatabase database;
+    FacebookImageCacheModel::ModelDataType type;
 
-public Q_SLOTS:
-    void queue(const QString &url, const QVariantMap &metadata);
-    void slotDataUpdated(const QString &url, const QString &path);
-
-Q_SIGNALS:
-    void typeChanged(int type);
-    void queueImages();
-
-protected:
-    void initWorkerObject(AbstractWorkerObject *workerObject);
-
-private:
-    QHash<QString, QVariantMap> m_queuedImages;
-    Q_DECLARE_PUBLIC(FacebookImageCacheModel)
 };
-
-FacebookImageWorkerObject::FacebookImageWorkerObject()
-    : AbstractWorkerObject(), FacebookImagesDatabase()
-    , type(FacebookImageCacheModel::None)
-    , m_enabled(false)
-{
-}
-
-FacebookImageWorkerObject::~FacebookImageWorkerObject()
-{
-}
-
-void FacebookImageWorkerObject::finalCleanup()
-{
-    closeDatabase();
-}
-
-void FacebookImageWorkerObject::refresh()
-{
-    // We initialize the database when refresh is called
-    // When it is called, we are sure that the object is already in a different thread
-    if (!m_enabled) {
-        initDatabase();
-        m_enabled = true;
-    }
-
-    SocialCacheModelData data;
-    switch (type) {
-        case FacebookImageCacheModel::Users: {
-            QList<FacebookUser::ConstPtr> usersData = users();
-            for (int i = 0; i < usersData.count(); i++) {
-                const FacebookUser::ConstPtr & userData = usersData.at(i);
-                QMap<int, QVariant> userMap;
-                userMap.insert(FacebookImageCacheModel::FacebookId, userData->fbUserId());
-                userMap.insert(FacebookImageCacheModel::Title, userData->userName());
-                userMap.insert(FacebookImageCacheModel::Count, userData->count());
-                data.append(userMap);
-            }
-
-            if (data.count() > 1) {
-                QMap<int, QVariant> userMap;
-                int count = 0;
-                foreach (const FacebookUser::ConstPtr &userData, usersData) {
-                    count += userData->count();
-                }
-
-                userMap.insert(FacebookImageCacheModel::FacebookId, QString());
-                userMap.insert(FacebookImageCacheModel::Thumbnail, QString());
-                //: Label for the "show all users from all Facebook accounts" option
-                //% "All"
-                userMap.insert(FacebookImageCacheModel::Title, qtTrId("nemo_socialcache_facebook_images_model-all-users"));
-                userMap.insert(FacebookImageCacheModel::Count, count);
-                data.prepend(userMap);
-            }
-        }
-        break;
-        case FacebookImageCacheModel::Albums: {
-            QList<FacebookAlbum::ConstPtr> albumsData = albums(nodeIdentifier);
-            foreach (const FacebookAlbum::ConstPtr & albumData, albumsData) {
-                QMap<int, QVariant> albumMap;
-                albumMap.insert(FacebookImageCacheModel::FacebookId, albumData->fbAlbumId());
-                albumMap.insert(FacebookImageCacheModel::Title, albumData->albumName());
-                albumMap.insert(FacebookImageCacheModel::Count, albumData->imageCount());
-                albumMap.insert(FacebookImageCacheModel::UserId, albumData->fbUserId());
-                data.append(albumMap);
-            }
-
-            if (data.count() > 1) {
-                QMap<int, QVariant> albumMap;
-                int count = 0;
-                foreach (const FacebookAlbum::ConstPtr &albumData, albumsData) {
-                    count += albumData->imageCount();
-                }
-
-                albumMap.insert(FacebookImageCacheModel::FacebookId, QString());
-                // albumMap.insert(FacebookImageCacheModel::Icon, QString());
-                //:  Label for the "show all photos from all albums (by this user or by all users, depending...)" option
-                //% "All"
-                albumMap.insert(FacebookImageCacheModel::Title, qtTrId("nemo_socialcache_facebook_images_model-all-albums"));
-                albumMap.insert(FacebookImageCacheModel::Count, count);
-                albumMap.insert(FacebookImageCacheModel::UserId, nodeIdentifier);
-                data.prepend(albumMap);
-            }
-        }
-        break;
-        case FacebookImageCacheModel::Images: {
-            QList<FacebookImage::ConstPtr> imagesData;
-            QString userPrefix = QLatin1String(PHOTO_USER_PREFIX);
-            QString albumPrefix = QLatin1String(PHOTO_ALBUM_PREFIX);
-            if (nodeIdentifier.startsWith(userPrefix)) {
-                QString userIdentifier = nodeIdentifier.mid(userPrefix.size());
-                imagesData = userImages(userIdentifier);
-            } else if (nodeIdentifier.startsWith(albumPrefix)) {
-                QString albumIdentifier = nodeIdentifier.mid(albumPrefix.size());
-                imagesData = albumImages(albumIdentifier);
-            } else {
-                imagesData = userImages();
-            }
-
-            for (int i = 0; i < imagesData.count(); i ++) {
-                const FacebookImage::ConstPtr & imageData = imagesData.at(i);
-                QMap<int, QVariant> imageMap;
-                imageMap.insert(FacebookImageCacheModel::FacebookId, imageData->fbImageId());
-                if (imageData->thumbnailFile().isEmpty()) {
-                    queueImageThumbnail(i, imageData);
-                }
-                imageMap.insert(FacebookImageCacheModel::Thumbnail, imageData->thumbnailFile());
-                if (imageData->imageFile().isEmpty()) {
-                    m_fullImages.append(qMakePair<FacebookImage::ConstPtr, int>(imageData, i));
-                }
-                imageMap.insert(FacebookImageCacheModel::Image, imageData->imageFile());
-                imageMap.insert(FacebookImageCacheModel::Title, imageData->imageName());
-                imageMap.insert(FacebookImageCacheModel::DateTaken, imageData->createdTime());
-                imageMap.insert(FacebookImageCacheModel::Width, imageData->width());
-                imageMap.insert(FacebookImageCacheModel::Height, imageData->height());
-                imageMap.insert(FacebookImageCacheModel::MimeType, QLatin1String("JPG"));
-                imageMap.insert(FacebookImageCacheModel::AccountId, imageData->account());
-                imageMap.insert(FacebookImageCacheModel::UserId, imageData->fbUserId());
-                data.append(imageMap);
-            }
-        }
-        break;
-        default: return; break;
-    }
-
-    emit dataUpdated(data);
-}
-
-void FacebookImageWorkerObject::setType(int typeToSet)
-{
-    type = static_cast<FacebookImageCacheModel::ModelDataType>(typeToSet);
-}
-
-void FacebookImageWorkerObject::queueImages()
-{
-    for (QList<QPair<FacebookImage::ConstPtr, int> >::const_iterator i = m_fullImages.begin();
-         i != m_fullImages.end(); i++) {
-        queueImageFull((*i).second, (*i).first);
-    }
-}
-
-void FacebookImageWorkerObject::queueImageThumbnail(int row, const FacebookImage::ConstPtr &image)
-{
-    queue(row, FacebookImageDownloaderWorkerObject::ThumbnailImage, image->fbImageId(),
-          image->thumbnailUrl());
-}
-
-void FacebookImageWorkerObject::queueImageFull(int row, const FacebookImage::ConstPtr &image)
-{
-    queue(row, FacebookImageDownloaderWorkerObject::FullImage, image->fbImageId(),
-          image->imageUrl());
-}
-
-void FacebookImageWorkerObject::queue(int row,
-                                      FacebookImageDownloaderWorkerObject::ImageType imageType,
-                                      const QString &identifier, const QString &url)
-{
-    QVariantMap metadata;
-    metadata.insert(QLatin1String(TYPE_KEY), imageType);
-    metadata.insert(QLatin1String(IDENTIFIER_KEY), identifier);
-    metadata.insert(QLatin1String(URL_KEY), url);
-    metadata.insert(QLatin1String(ROW_KEY), row);
-    emit requestQueue(url, metadata);
-}
 
 FacebookImageCacheModelPrivate::FacebookImageCacheModelPrivate(FacebookImageCacheModel *q)
-    : AbstractSocialCacheModelPrivate(q), downloader(0)
+    : AbstractSocialCacheModelPrivate(q), downloader(0), type(FacebookImageCacheModel::Images)
 {
 }
 
-void FacebookImageCacheModelPrivate::queue(const QString &url, const QVariantMap &metadata)
+void FacebookImageCacheModelPrivate::queue(
+        int row,
+        FacebookImageDownloader::ImageType imageType,
+        const QString &identifier,
+        const QString &url)
 {
-    m_queuedImages.insert(url, metadata);
-}
+    if (downloader) {
+        QVariantMap metadata;
+        metadata.insert(QLatin1String(TYPE_KEY), imageType);
+        metadata.insert(QLatin1String(IDENTIFIER_KEY), identifier);
+        metadata.insert(QLatin1String(URL_KEY), url);
+        metadata.insert(QLatin1String(ROW_KEY), row);
 
-void FacebookImageCacheModelPrivate::slotDataUpdated(const QString &url, const QString &path)
-{
-    Q_Q(FacebookImageCacheModel);
-    if (m_queuedImages.contains(url)) {
-        QVariantMap imageData = m_queuedImages.value(url);
-        int row = imageData.value(ROW_KEY).toInt();
-        if (row < 0 || row >= m_data.count()) {
-            qWarning() << Q_FUNC_INFO << "Incorrect number of rows" << imageData.count();
-            return;
-        }
-
-        int type = imageData.value(TYPE_KEY).toInt();
-        switch (type) {
-        case FacebookImageDownloaderWorkerObject::ThumbnailImage:
-            m_data[row].insert(FacebookImageCacheModel::Thumbnail, path);
-            break;
-        case FacebookImageDownloaderWorkerObject::FullImage:
-            m_data[row].insert(FacebookImageCacheModel::Image, path);
-            break;
-        }
-
-        emit q->dataChanged(q->index(row), q->index(row));
+        downloader->queue(url, metadata);
     }
-}
-
-void FacebookImageCacheModelPrivate::initWorkerObject(AbstractWorkerObject *workerObject)
-{
-    FacebookImageWorkerObject *facebookImageWorkerObject
-            = qobject_cast<FacebookImageWorkerObject *>(workerObject);
-    if (!facebookImageWorkerObject) {
-        return;
-    }
-
-    connect(facebookImageWorkerObject, &FacebookImageWorkerObject::requestQueue,
-            this, &FacebookImageCacheModelPrivate::queue);
-    connect(this, &FacebookImageCacheModelPrivate::queueImages,
-            facebookImageWorkerObject, &FacebookImageWorkerObject::queueImages);
-    connect(this, &FacebookImageCacheModelPrivate::typeChanged,
-            facebookImageWorkerObject, &FacebookImageWorkerObject::setType);
-
-    AbstractSocialCacheModelPrivate::initWorkerObject(workerObject);
 }
 
 FacebookImageCacheModel::FacebookImageCacheModel(QObject *parent)
     : AbstractSocialCacheModel(*(new FacebookImageCacheModelPrivate(this)), parent)
 {
-    Q_D(FacebookImageCacheModel);
-    d->initWorkerObject(new FacebookImageWorkerObject());
+    Q_D(const FacebookImageCacheModel);
+    connect(&d->database, &FacebookImagesDatabase::queryFinished,
+            this, &FacebookImageCacheModel::queryFinished);
 }
 
 QHash<int, QByteArray> FacebookImageCacheModel::roleNames() const
@@ -355,7 +120,6 @@ void FacebookImageCacheModel::setType(FacebookImageCacheModel::ModelDataType typ
     if (d->type != type) {
         d->type = type;
         emit typeChanged();
-        emit d->typeChanged(type);
     }
 }
 
@@ -371,33 +135,172 @@ void FacebookImageCacheModel::setDownloader(FacebookImageDownloader *downloader)
     if (d->downloader != downloader) {
         if (d->downloader) {
             // Disconnect worker object
-            d->m_workerObject->disconnect(d->downloader->workerObject());
-            d->downloader->workerObject()->disconnect(d);
+            disconnect(d->downloader);
         }
 
         d->downloader = downloader;
 
         // Needed for the new Qt connection system
-        FacebookImageWorkerObject *imageWorkerObject
-                = qobject_cast<FacebookImageWorkerObject *>(d->m_workerObject);
-        connect(imageWorkerObject, &FacebookImageWorkerObject::requestQueue,
-                d->downloader->workerObject(), &AbstractImageDownloader::queue);
-        connect(d->downloader->workerObject(), &AbstractImageDownloader::imageDownloaded,
-                d, &FacebookImageCacheModelPrivate::slotDataUpdated);
+        connect(d->downloader, &AbstractImageDownloader::imageDownloaded,
+                this, &FacebookImageCacheModel::imageDownloaded);
 
         emit downloaderChanged();
     }
 }
 
-// Used to queue high-res photos to be loaded
 void FacebookImageCacheModel::loadImages()
 {
+    refresh();
+}
+
+void FacebookImageCacheModel::refresh()
+{
     Q_D(FacebookImageCacheModel);
-    if (d->type != Images) {
+
+    const QString userPrefix = QLatin1String(PHOTO_USER_PREFIX);
+    const QString albumPrefix = QLatin1String(PHOTO_ALBUM_PREFIX);
+
+    switch (d->type) {
+    case FacebookImageCacheModel::Users:
+        d->database.queryUsers();
+        break;
+    case FacebookImageCacheModel::Albums:
+        d->database.queryAlbums(d->nodeIdentifier);
+        break;
+    case FacebookImageCacheModel::Images:
+        if (d->nodeIdentifier.startsWith(userPrefix)) {
+            d->database.queryUserImages(d->nodeIdentifier.mid(userPrefix.size()));
+        } else if (d->nodeIdentifier.startsWith(albumPrefix)) {
+            d->database.queryAlbumImages(d->nodeIdentifier.mid(albumPrefix.size()));
+        } else {
+            d->database.queryUserImages();
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+void FacebookImageCacheModel::imageDownloaded(
+        const QString &, const QString &path, const QVariantMap &imageData)
+{
+    Q_D(FacebookImageCacheModel);
+
+    int row = imageData.value(ROW_KEY).toInt();
+    if (row < 0 || row >= d->m_data.count()) {
+        qWarning() << Q_FUNC_INFO << "Incorrect number of rows" << imageData.count();
         return;
     }
 
-    emit d->queueImages();
+    int type = imageData.value(TYPE_KEY).toInt();
+    switch (type) {
+    case FacebookImageDownloader::ThumbnailImage:
+        d->m_data[row].insert(FacebookImageCacheModel::Thumbnail, path);
+        break;
+    case FacebookImageDownloader::FullImage:
+        d->m_data[row].insert(FacebookImageCacheModel::Image, path);
+        break;
+    }
+
+    emit dataChanged(index(row), index(row));
 }
 
-#include "facebookimagecachemodel.moc"
+void FacebookImageCacheModel::queryFinished()
+{
+    Q_D(FacebookImageCacheModel);
+
+    SocialCacheModelData data;
+    switch (d->type) {
+    case Users: {
+        QList<FacebookUser::ConstPtr> usersData = d->database.users();
+        for (int i = 0; i < usersData.count(); i++) {
+            const FacebookUser::ConstPtr & userData = usersData.at(i);
+            QMap<int, QVariant> userMap;
+            userMap.insert(FacebookImageCacheModel::FacebookId, userData->fbUserId());
+            userMap.insert(FacebookImageCacheModel::Title, userData->userName());
+            userMap.insert(FacebookImageCacheModel::Count, userData->count());
+            data.append(userMap);
+        }
+
+        if (data.count() > 1) {
+            QMap<int, QVariant> userMap;
+            int count = 0;
+            Q_FOREACH (const FacebookUser::ConstPtr &userData, usersData) {
+                count += userData->count();
+            }
+
+            userMap.insert(FacebookImageCacheModel::FacebookId, QString());
+            userMap.insert(FacebookImageCacheModel::Thumbnail, QString());
+            //: Label for the "show all users from all Facebook accounts" option
+            //% "All"
+            userMap.insert(FacebookImageCacheModel::Title, qtTrId("nemo_socialcache_facebook_images_model-all-users"));
+            userMap.insert(FacebookImageCacheModel::Count, count);
+            data.prepend(userMap);
+        }
+        break;
+    }
+    case Albums: {
+        QList<FacebookAlbum::ConstPtr> albumsData = d->database.albums();
+        Q_FOREACH (const FacebookAlbum::ConstPtr & albumData, albumsData) {
+            QMap<int, QVariant> albumMap;
+            albumMap.insert(FacebookImageCacheModel::FacebookId, albumData->fbAlbumId());
+            albumMap.insert(FacebookImageCacheModel::Title, albumData->albumName());
+            albumMap.insert(FacebookImageCacheModel::Count, albumData->imageCount());
+            albumMap.insert(FacebookImageCacheModel::UserId, albumData->fbUserId());
+            data.append(albumMap);
+        }
+
+        if (data.count() > 1) {
+            QMap<int, QVariant> albumMap;
+            int count = 0;
+            Q_FOREACH (const FacebookAlbum::ConstPtr &albumData, albumsData) {
+                count += albumData->imageCount();
+            }
+
+            albumMap.insert(FacebookImageCacheModel::FacebookId, QString());
+            // albumMap.insert(FacebookImageCacheModel::Icon, QString());
+            //:  Label for the "show all photos from all albums (by this user or by all users, depending...)" option
+            //% "All"
+            albumMap.insert(FacebookImageCacheModel::Title, qtTrId("nemo_socialcache_facebook_images_model-all-albums"));
+            albumMap.insert(FacebookImageCacheModel::Count, count);
+            albumMap.insert(FacebookImageCacheModel::UserId, QString());
+            data.prepend(albumMap);
+        }
+        break;
+    }
+    case Images: {
+        QList<FacebookImage::ConstPtr> imagesData = d->database.images();
+
+        for (int i = 0; i < imagesData.count(); i ++) {
+            const FacebookImage::ConstPtr & imageData = imagesData.at(i);
+            QMap<int, QVariant> imageMap;
+            imageMap.insert(FacebookImageCacheModel::FacebookId, imageData->fbImageId());
+            if (imageData->thumbnailFile().isEmpty()) {
+                d->queue(i, FacebookImageDownloader::ThumbnailImage,
+                            imageData->fbImageId(),
+                            imageData->thumbnailUrl());
+            }
+            imageMap.insert(FacebookImageCacheModel::Thumbnail, imageData->thumbnailFile());
+            if (imageData->imageFile().isEmpty()) {
+                d->queue(i, FacebookImageDownloader::FullImage,
+                            imageData->fbImageId(),
+                            imageData->imageUrl());
+            }
+            imageMap.insert(FacebookImageCacheModel::Image, imageData->imageFile());
+            imageMap.insert(FacebookImageCacheModel::Title, imageData->imageName());
+            imageMap.insert(FacebookImageCacheModel::DateTaken, imageData->createdTime());
+            imageMap.insert(FacebookImageCacheModel::Width, imageData->width());
+            imageMap.insert(FacebookImageCacheModel::Height, imageData->height());
+            imageMap.insert(FacebookImageCacheModel::MimeType, QLatin1String("image/jpeg"));
+            imageMap.insert(FacebookImageCacheModel::AccountId, imageData->account());
+            imageMap.insert(FacebookImageCacheModel::UserId, imageData->fbUserId());
+            data.append(imageMap);
+        }
+        break;
+    }
+    default:
+        return;
+    }
+
+    updateData(data);
+}

--- a/src/qml/facebook/facebookimagecachemodel.h
+++ b/src/qml/facebook/facebookimagecachemodel.h
@@ -69,10 +69,15 @@ public:
 
 public Q_SLOTS:
     void loadImages();
+    void refresh();
 
 Q_SIGNALS:
     void typeChanged();
     void downloaderChanged();
+
+private Q_SLOTS:
+    void queryFinished();
+    void imageDownloaded(const QString &url, const QString &path, const QVariantMap &imageData);
 
 private:
     Q_DECLARE_PRIVATE(FacebookImageCacheModel)

--- a/src/qml/facebook/facebookimagedownloader.h
+++ b/src/qml/facebook/facebookimagedownloader.h
@@ -22,17 +22,28 @@
 
 #include <QtCore/QObject>
 
+#include "abstractimagedownloader.h"
+
 class FacebookImageDownloaderWorkerObject;
 class FacebookImageDownloaderPrivate;
-class FacebookImageDownloader : public QObject
+class FacebookImageDownloader : public AbstractImageDownloader
 {
     Q_OBJECT
 public:
+    enum ImageType {
+        ThumbnailImage,
+        FullImage
+    };
+
     explicit FacebookImageDownloader(QObject *parent = 0);
     virtual ~FacebookImageDownloader();
-    FacebookImageDownloaderWorkerObject * workerObject() const;
+
 protected:
-    QScopedPointer<FacebookImageDownloaderPrivate> d_ptr;
+    QString outputFile(const QString &url, const QVariantMap &data) const;
+
+    void dbQueueImage(const QString &url, const QVariantMap &data, const QString &file);
+    void dbWrite();
+
 private:
     Q_DECLARE_PRIVATE(FacebookImageDownloader)
 };

--- a/src/qml/facebook/facebookimagedownloader_p.h
+++ b/src/qml/facebook/facebookimagedownloader_p.h
@@ -25,80 +25,21 @@
 #include <QtCore/QMutex>
 #include <QtCore/QWaitCondition>
 
-#include "abstractimagedownloader.h"
+#include "abstractimagedownloader_p.h"
+#include "facebookimagedownloader.h"
 #include "facebookimagesdatabase.h"
 
-class FacebookImageDownloaderWorkerObject;
-class AbstractSocialCacheModel;
-class FacebookImageDownloader;
-class FacebookImageDownloaderPrivate: public QObject
-{
-    Q_OBJECT
 
+class FacebookImageDownloaderPrivate: public AbstractImageDownloaderPrivate
+{
 public:
     explicit FacebookImageDownloaderPrivate(FacebookImageDownloader *q);
     virtual ~FacebookImageDownloaderPrivate();
 
-protected:
-    FacebookImageDownloader * const q_ptr;
+    FacebookImagesDatabase database;
 
 private:
-    QThread m_workerThread;
-    FacebookImageDownloaderWorkerObject *m_workerObject;
     Q_DECLARE_PUBLIC(FacebookImageDownloader)
-};
-
-
-// We try to minimize the use of signals and slots exposed to QML,
-// so we FacebookImageDownloader only expose one method in C++.
-// This method exposes the FacebookImageDownloaderWorkerObject.
-//
-// FacebookImageDownloaderWorkerObject is a subclass of AbstractImagesDownloader,
-// and is an image downloader object. It lives in it's own low priority thread.
-//
-// The call path that is being done is
-// FacebookImageWorkerObject::refresh calls FacebookImageWorkerObject::queue.
-// This triggers an emission of requestQueue. This signal is connected to
-// FacebookImageDownloaderWorkerObject::queue, so FacebookImageDownloaderWorkerObject
-// starts downloading data. When data is downloaded,
-// FacebookImageDownloaderWorkerObject::imageDownloaded is sent, and triggers
-// FacebookImageCacheModelPrivate::slotDataUpdated that changes the model.
-//
-// Basically we communicates between internal objects, and never touch the
-// QML API.
-
-class FacebookImageDownloaderWorkerObject: public AbstractImageDownloader
-{
-    Q_OBJECT
-public:
-    enum ImageType {
-        InvalidImage,
-        ThumbnailImage,
-        FullImage
-    };
-
-    explicit FacebookImageDownloaderWorkerObject();
-
-public Q_SLOTS:
-    void quitGracefully();
-
-protected:
-    QString outputFile(const QString &url, const QVariantMap &data) const;
-    bool dbInit();
-    void dbQueueImage(const QString &url, const QVariantMap &data, const QString &file);
-    void dbWrite();
-    bool dbClose();
-
-private:
-    bool m_initialized;
-    FacebookImagesDatabase m_db;
-
-    bool m_killed;
-
-private:
-    friend class FacebookImageDownloaderPrivate;
-    QMutex m_quitMutex;
-    QWaitCondition m_quitWC;
 };
 
 #endif // FACEBOOKIMAGEDOWNLOADER_P_H

--- a/src/qml/facebook/facebookpostsmodel.h
+++ b/src/qml/facebook/facebookpostsmodel.h
@@ -45,6 +45,12 @@ public:
     };
     explicit FacebookPostsModel(QObject *parent = 0);
     QHash<int, QByteArray> roleNames() const;
+
+    void refresh();
+
+private Q_SLOTS:
+    void postsChanged();
+
 private:
     Q_DECLARE_PRIVATE(FacebookPostsModel)
 };

--- a/src/qml/twitter/twitterpostsmodel.h
+++ b/src/qml/twitter/twitterpostsmodel.h
@@ -42,6 +42,12 @@ public:
     };
     explicit TwitterPostsModel(QObject *parent = 0);
     QHash<int, QByteArray> roleNames() const;
+
+    void refresh();
+
+private slots:
+    void postsChanged();
+
 private:
     Q_DECLARE_PRIVATE(TwitterPostsModel)
 };

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,2 +1,9 @@
 TEMPLATE = subdirs
-SUBDIRS = tst_abstractsocialcachedatabase tst_facebookimage
+SUBDIRS = \
+        tst_abstractsocialcachedatabase \
+        tst_facebookcalendar \
+        tst_facebookcontact \
+        tst_facebookimage \
+        tst_facebookpost \
+        tst_socialnetworksync \
+        tst_twitterpost

--- a/tests/tst_abstractsocialcachedatabase/tst_abstractsocialcachedatabase.pro
+++ b/tests/tst_abstractsocialcachedatabase/tst_abstractsocialcachedatabase.pro
@@ -14,3 +14,5 @@ SOURCES +=  ../../src/lib/abstractsocialcachedatabase.cpp \
             ../../src/lib/semaphore_p.cpp \
             main.cpp
 
+target.path = /opt/tests/libsocialcache
+INSTALLS += target

--- a/tests/tst_facebookcalendar/main.cpp
+++ b/tests/tst_facebookcalendar/main.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd. <lucien.xu@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtTest/QTest>
+#include "facebookcalendardatabase.h"
+#include "socialsyncinterface.h"
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QStandardPaths>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+class FacebookCalendarTest: public QObject
+{
+    Q_OBJECT
+private:
+
+private slots:
+    // Perform some cleanups
+    // we basically remove the whole ~/.local/share/system/privileged. While it is
+    // damaging on a device, on a desktop system it should not be much
+    // damaging.
+    void initTestCase()
+    {
+        QStandardPaths::enableTestMode(true);
+
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+    }
+
+    void events()
+    {
+        FacebookCalendarDatabase database;
+
+        const QString event1 = QLatin1String("event1");
+        const QString event2 = QLatin1String("event2");
+        const QString event3 = QLatin1String("event3");
+        const QString event4 = QLatin1String("event4");
+        const QString event5 = QLatin1String("event5");
+
+        const QString incidence1 = QLatin1String("incidence1");
+        const QString incidence2 = QLatin1String("incidence2");
+        const QString incidence3 = QLatin1String("incidence3");
+
+        database.addSyncedEvent(event1, 1, incidence1);
+        database.addSyncedEvent(event2, 1, incidence1);
+        database.addSyncedEvent(event3, 1, incidence2);
+        database.addSyncedEvent(event4, 2, incidence1);
+        database.addSyncedEvent(event5, 2, incidence3);
+
+        database.sync(1);
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        QList<FacebookEvent::ConstPtr> events;
+
+        events = database.events(1);
+        QCOMPARE(events.count(), 3);
+
+        events = database.events(2);
+        QCOMPARE(events.count(), 0);
+
+        database.sync(2);
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        events = database.events(2);
+        QCOMPARE(events.count(), 2);
+
+        if (events.first()->fbEventId() == event5) {
+            events.prepend(events.takeLast());
+        }
+
+        QCOMPARE(events.at(0)->fbEventId(), event4);
+        QCOMPARE(events.at(0)->accountId(), 2);
+        QCOMPARE(events.at(0)->incidenceId(), incidence1);
+
+        QCOMPARE(events.at(1)->fbEventId(), event5);
+        QCOMPARE(events.at(1)->accountId(), 2);
+        QCOMPARE(events.at(1)->incidenceId(), incidence3);
+
+        database.removeEvents(1);
+        database.sync(1);
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        events = database.events(1);
+        QCOMPARE(events.count(), 0);
+
+        events = database.events(2);
+        QCOMPARE(events.count(), 2);
+
+        database.removeEvents(2);
+        database.sync(2);
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        events = database.events(1);
+        QCOMPARE(events.count(), 0);
+
+        events = database.events(2);
+        QCOMPARE(events.count(), 0);
+    }
+
+    void cleanupTestCase()
+    {
+        // Do the same cleanups
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+
+    }
+};
+
+QTEST_MAIN(FacebookCalendarTest)
+
+#include "main.moc"

--- a/tests/tst_facebookcalendar/tst_facebookcalendar.pro
+++ b/tests/tst_facebookcalendar/tst_facebookcalendar.pro
@@ -1,0 +1,24 @@
+include(../../common.pri)
+
+TEMPLATE = app
+TARGET = tst_facebookcalendar
+QT += network sql testlib
+
+DEFINES += NO_KEY_PROVIDER
+
+INCLUDEPATH += ../../src/lib/
+
+HEADERS +=  ../../src/lib/semaphore_p.h \
+            ../../src/lib/socialsyncinterface.h \
+            ../../src/lib/abstractsocialcachedatabase.h \
+            ../../src/lib/abstractsocialcachedatabase_p.h \
+            ../../src/lib/facebookcalendardatabase.h
+
+SOURCES +=  ../../src/lib/semaphore_p.cpp \
+            ../../src/lib/socialsyncinterface.cpp \
+            ../../src/lib/abstractsocialcachedatabase.cpp \
+            ../../src/lib/facebookcalendardatabase.cpp \
+            main.cpp
+
+target.path = /opt/tests/libsocialcache
+INSTALLS += target

--- a/tests/tst_facebookcontact/main.cpp
+++ b/tests/tst_facebookcontact/main.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd. <lucien.xu@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtTest/QTest>
+#include "facebookcontactsdatabase.h"
+#include "socialsyncinterface.h"
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QStandardPaths>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+class FacebookContactsTest: public QObject
+{
+    Q_OBJECT
+private:
+
+private slots:
+    // Perform some cleanups
+    // we basically remove the whole ~/.local/share/system/privileged. While it is
+    // damaging on a device, on a desktop system it should not be much
+    // damaging.
+    void initTestCase()
+    {
+        QStandardPaths::enableTestMode(true);
+
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+    }
+
+    void contacts()
+    {
+        FacebookContactsDatabase database;
+
+        const QString friend1 = QLatin1String("friend1");
+        const QString friend2 = QLatin1String("friend2");
+        const QString friend3 = QLatin1String("friend3");
+        const QString friend4 = QLatin1String("friend4");
+        const QString friend5 = QLatin1String("friend5");
+
+        const QString pictureUrl1 = QLatin1String("http://example.com/friend1.jpg");
+        const QString pictureUrl2 = QLatin1String("http://example.com/friend1.jpg");
+        const QString coverUrl1 = QLatin1String("http://example.com/cover1.jpg");
+        const QString coverUrl2 = QLatin1String("http://example.com/cover2.jpg");
+
+        const QString pictureFile1 = QLatin1String("/temp/friend1.jpg");
+        const QString coverFile1 = QLatin1String("/temp/cover1.jpg");
+
+        database.addSyncedContact(friend1, 1, pictureUrl1, coverUrl1);
+        database.addSyncedContact(friend2, 1, pictureUrl2, coverUrl2);
+        database.addSyncedContact(friend3, 1, pictureUrl1, coverUrl1);
+        database.addSyncedContact(friend4, 1, pictureUrl1, coverUrl1);
+        database.addSyncedContact(friend1, 2, pictureUrl1, coverUrl1);
+        database.addSyncedContact(friend4, 2, pictureUrl1, coverUrl1);
+        database.addSyncedContact(friend5, 2, pictureUrl1, coverUrl1);
+
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        FacebookContact::ConstPtr contact;
+
+        contact = database.contact(friend1, 1);
+        QCOMPARE(contact->fbFriendId(), friend1);
+        QCOMPARE(contact->accountId(), 1);
+        QCOMPARE(contact->pictureUrl(), pictureUrl1);
+        QCOMPARE(contact->coverUrl(), coverUrl1);
+        QCOMPARE(contact->pictureFile(), QString());
+        QCOMPARE(contact->coverFile(), QString());
+
+        contact = database.contact(friend1, 2);
+        QCOMPARE(contact->fbFriendId(), friend1);
+        QCOMPARE(contact->accountId(), 2);
+        QCOMPARE(contact->pictureUrl(), pictureUrl1);
+        QCOMPARE(contact->coverUrl(), coverUrl1);
+        QCOMPARE(contact->pictureFile(), QString());
+        QCOMPARE(contact->coverFile(), QString());
+
+        database.updatePictureFile(friend1, pictureFile1);
+        database.updateCoverFile(friend1, coverFile1);
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        contact = database.contact(friend1, 1);
+        QCOMPARE(contact->pictureFile(), pictureFile1);
+        QCOMPARE(contact->coverFile(), coverFile1);
+
+        contact = database.contact(friend1, 2);
+        QCOMPARE(contact->pictureFile(), pictureFile1);
+        QCOMPARE(contact->coverFile(), coverFile1);
+
+        QList<FacebookContact::ConstPtr> contacts;
+
+        contacts = database.contacts(1);
+        QCOMPARE(contacts.count(), 4);
+
+        contacts = database.contacts(2);
+        QCOMPARE(contacts.count(), 3);
+
+        database.removeContacts(QStringList() << friend1 << friend2);
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        contacts = database.contacts(1);
+        QCOMPARE(contacts.count(), 2);
+
+        contacts = database.contacts(2);
+        QCOMPARE(contacts.count(), 2);
+
+        database.removeContacts(1);
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        contacts = database.contacts(1);
+        QCOMPARE(contacts.count(), 0);
+
+        contacts = database.contacts(2);
+        QCOMPARE(contacts.count(), 2);
+
+        database.removeContacts(2);
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        contacts = database.contacts(2);
+        QCOMPARE(contacts.count(), 0);
+    }
+
+    void cleanupTestCase()
+    {
+        // Do the same cleanups
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+
+    }
+};
+
+QTEST_MAIN(FacebookContactsTest)
+
+#include "main.moc"

--- a/tests/tst_facebookcontact/tst_facebookcontact.pro
+++ b/tests/tst_facebookcontact/tst_facebookcontact.pro
@@ -1,0 +1,24 @@
+include(../../common.pri)
+
+TEMPLATE = app
+TARGET = tst_facebookcontact
+QT += network sql testlib
+
+DEFINES += NO_KEY_PROVIDER
+
+INCLUDEPATH += ../../src/lib/
+
+HEADERS +=  ../../src/lib/semaphore_p.h \
+            ../../src/lib/socialsyncinterface.h \
+            ../../src/lib/abstractsocialcachedatabase.h \
+            ../../src/lib/abstractsocialcachedatabase_p.h \
+            ../../src/lib/facebookcontactsdatabase.h
+
+SOURCES +=  ../../src/lib/semaphore_p.cpp \
+            ../../src/lib/socialsyncinterface.cpp \
+            ../../src/lib/abstractsocialcachedatabase.cpp \
+            ../../src/lib/facebookcontactsdatabase.cpp \
+            main.cpp
+
+target.path = /opt/tests/libsocialcache
+INSTALLS += target

--- a/tests/tst_facebookimage/main.cpp
+++ b/tests/tst_facebookimage/main.cpp
@@ -43,8 +43,7 @@ class FacebookImageTest: public QObject
 {
     Q_OBJECT
 private:
-    FacebookImagesDatabase *fbDb;
-    QSqlDatabase *checkDb;
+
 private slots:
     // Perform some cleanups
     // we basically remove the whole ~/.local/share/system/privileged. While it is
@@ -56,29 +55,29 @@ private slots:
 
         QDir dir (PRIVILEGED_DATA_DIR);
         dir.removeRecursively();
+    }
 
-        // Will create the database
-        fbDb = new FacebookImagesDatabase();
-        fbDb->initDatabase();
+    void testAddUser()
+    {
+        FacebookImagesDatabase database;
+
+        QDateTime time1 (QDate(2013, 1, 2), QTime(12, 34, 56));
+
+        database.addUser("a", time1, "c");
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
 
         QString dataType = SocialSyncInterface::dataType(SocialSyncInterface::Images);
         QString dbFile = QLatin1String("facebook.db"); // DB_NAME in facebookimagesdatabase.cpp
 
 
-        checkDb = new QSqlDatabase(QSqlDatabase::addDatabase("QSQLITE"));
-        checkDb->setDatabaseName(QString("%1/%2/%3").arg(PRIVILEGED_DATA_DIR, dataType, dbFile));
-        QVERIFY(checkDb->open());
-    }
-
-    void testAddUser()
-    {
-        QDateTime time1 (QDate(2013, 1, 2), QTime(12, 34, 56));
-
-        fbDb->addUser("a", time1, "c");
-        QVERIFY(fbDb->write());
+        QSqlDatabase checkDb = QSqlDatabase::addDatabase("QSQLITE");
+        checkDb.setDatabaseName(QString("%1/%2/%3").arg(PRIVILEGED_DATA_DIR, dataType, dbFile));
+        QVERIFY(checkDb.open());
 
         // Check if the user has been written
-        QSqlQuery query (*checkDb);
+        QSqlQuery query (checkDb);
         query.prepare("SELECT fbUserId, updatedTime, userName "\
                       "FROM users");
         QVERIFY(query.exec());
@@ -89,7 +88,7 @@ private slots:
         QVERIFY(!query.next());
 
         // Check if we can retrieve the user
-        FacebookUser::ConstPtr user = fbDb->user(QLatin1String("a"));
+        FacebookUser::ConstPtr user = database.user(QLatin1String("a"));
         QCOMPARE(user->fbUserId(), QLatin1String("a"));
         QCOMPARE(user->updatedTime(), time1);
         QCOMPARE(user->userName(), QLatin1String("c"));
@@ -98,11 +97,15 @@ private slots:
         QDateTime time2 (QDate(2012, 3, 4), QTime(10, 11, 12));
 
         // Let's write another user
-        fbDb->addUser("d", time2, "f");
-        QVERIFY(fbDb->write());
+        database.addUser("d", time2, "f");
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
 
         // Check if we can retrieve everybody
-        QList<FacebookUser::ConstPtr> users = fbDb->users();
+        database.queryUsers();
+        database.wait();
+        QList<FacebookUser::ConstPtr> users = database.users();
         QCOMPARE(users.count(), 2);
         QCOMPARE(users[0]->fbUserId(), QLatin1String("a"));
         QCOMPARE(users[0]->updatedTime(), time1);
@@ -118,8 +121,400 @@ private slots:
         model.setType(FacebookImageCacheModel::Users);
         model.refresh();
         QCOMPARE(model.count(), 0);
-        QTest::qSleep(1000);
-        QCOMPARE(model.count(), 2);
+        QTRY_COMPARE(model.count(), 3);
+
+        database.removeUser(QLatin1String("a"));
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        model.refresh();
+        QTRY_COMPARE(model.count(), 1);
+
+        database.removeUser(QLatin1String("d"));
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        model.refresh();
+        QTRY_COMPARE(model.count(), 0);
+    }
+
+    void albums()
+    {
+        QDateTime time1(QDate(2013, 1, 2), QTime(12, 34, 56));
+        QDateTime time2(QDate(2012, 3, 4), QTime(10, 11, 12));
+
+        const QString user1 = QLatin1String("user1");
+        const QString user2 = QLatin1String("user2");
+        const QString album1 = QLatin1String("album1");
+        const QString album2 = QLatin1String("album2");
+        const QString album3 = QLatin1String("album3");
+
+        FacebookImagesDatabase database;
+
+        database.addUser(user1, time1, QLatin1String("joe"));
+        database.addUser(user2, time2, QLatin1String("dave"));
+
+        database.addAlbum(album1, user1, time1, time2, QLatin1String("holidays"), 3);
+        database.addAlbum(album2, user1, time2, time1, QLatin1String("work"), 2);
+        database.addAlbum(album3, user2, time1, time2, QLatin1String("holidays"), 4);
+
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        bool ok = false;
+        QStringList albumIds = database.allAlbumIds(&ok);
+        QCOMPARE(ok, true);
+        QCOMPARE(albumIds.contains(album1), true);
+        QCOMPARE(albumIds.contains(album2), true);
+        QCOMPARE(albumIds.contains(album3), true);
+
+        FacebookAlbum::ConstPtr album;
+
+        album = database.album(album1);
+        QCOMPARE(album->fbAlbumId(), album1);
+        QCOMPARE(album->fbUserId(), user1);
+        QCOMPARE(album->createdTime(), time1);
+        QCOMPARE(album->updatedTime(), time2);
+        QCOMPARE(album->albumName(), QLatin1String("holidays"));
+        QCOMPARE(album->imageCount(), 3);
+
+        album = database.album(album2);
+        QCOMPARE(album->fbAlbumId(), album2);
+        QCOMPARE(album->fbUserId(), user1);
+        QCOMPARE(album->createdTime(), time2);
+        QCOMPARE(album->updatedTime(), time1);
+        QCOMPARE(album->albumName(), QLatin1String("work"));
+        QCOMPARE(album->imageCount(), 2);
+
+        album = database.album(album3);
+        QCOMPARE(album->fbAlbumId(), album3);
+        QCOMPARE(album->fbUserId(), user2);
+        QCOMPARE(album->createdTime(), time1);
+        QCOMPARE(album->updatedTime(), time2);
+        QCOMPARE(album->albumName(), QLatin1String("holidays"));
+        QCOMPARE(album->imageCount(), 4);
+
+        QList<FacebookAlbum::ConstPtr> albums;
+
+        database.queryAlbums();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 3);
+
+        database.queryAlbums(user1);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 2);
+
+        database.queryAlbums(user2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 1);
+
+        database.removeAlbum(album2);
+        database.commit();
+
+        database.queryAlbums();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 2);
+
+        database.queryAlbums(user1);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 1);
+
+        database.queryAlbums(user2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 1);
+
+        database.removeUser(user2);
+        database.commit();
+
+        database.queryAlbums();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 1);
+
+        database.queryAlbums(user1);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 1);
+
+        database.queryAlbums(user2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        albums = database.albums();
+        QCOMPARE(albums.count(), 0);
+    }
+
+    void images()
+    {
+        QDateTime time1(QDate(2013, 1, 2), QTime(12, 34, 56));
+        QDateTime time2(QDate(2012, 3, 4), QTime(10, 11, 12));
+
+        const QString user1 = QLatin1String("user1");
+        const QString user2 = QLatin1String("user2");
+        const QString album1 = QLatin1String("album1");
+        const QString album2 = QLatin1String("album2");
+        const QString album3 = QLatin1String("album3");
+        const QString image1 = QLatin1String("image1");
+        const QString image2 = QLatin1String("image2");
+        const QString image3 = QLatin1String("image3");
+        const QString image4 = QLatin1String("image4");
+        const QString image5 = QLatin1String("image5");
+        const QString image6 = QLatin1String("image6");
+        const QString image7 = QLatin1String("image7");
+        const QString image8 = QLatin1String("image8");
+        const QString image9 = QLatin1String("image9");
+
+        FacebookImagesDatabase database;
+
+        database.addUser(user1, time1, QLatin1String("joe"));
+        database.addUser(user2, time2, QLatin1String("dave"));
+
+        database.syncAccount(1, user1);
+        database.syncAccount(2, user2);
+
+        database.addAlbum(album1, user1, time1, time2, QLatin1String("holidays"), 3);
+        database.addAlbum(album2, user1, time2, time1, QLatin1String("work"), 2);
+        database.addAlbum(album3, user2, time1, time2, QLatin1String("holidays"), 4);
+
+        database.addImage(
+                    image1, album1, user1,
+                    time1, time2,
+                    QLatin1String("1"),
+                    640, 480,
+                    QLatin1String("file:///t1.jpg"), QLatin1String("file:///1.jpg"));
+        database.addImage(
+                    image2, album1, user1,
+                    time1, time1,
+                    QLatin1String("2"),
+                    480, 640,
+                    QLatin1String("file:///t2.jpg"), QLatin1String("file:///2.jpg"));
+        database.addImage(
+                    image3, album1, user1,
+                    time2, time1,
+                    QLatin1String("3"),
+                    640, 480,
+                    QLatin1String("file:///t3.jpg"), QLatin1String("file:///3.jpg"));
+        database.addImage(
+                    image4, album2, user1,
+                    time1, time1,
+                    QLatin1String("4"),
+                    640, 480,
+                    QLatin1String("file:///t4.jpg"), QLatin1String("file:///4.jpg"));
+        database.addImage(
+                    image5, album2, user1,
+                    time1, time2,
+                    QLatin1String("5"),
+                    480, 640,
+                    QLatin1String("file:///t5.jpg"), QLatin1String("file:///5.jpg"));
+
+        database.addImage(
+                    image6, album3, user2,
+                    time1, time2,
+                    QLatin1String("6"),
+                    640, 480,
+                    QLatin1String("file:///t6.jpg"), QLatin1String("file:///6.jpg"));
+
+        database.addImage(
+                    image7, album3, user2,
+                    time1, time2,
+                    QLatin1String("7"),
+                    640, 480,
+                    QLatin1String("file:///t7.jpg"), QLatin1String("file:///7.jpg"));
+        database.addImage(
+                    image8, album3, user2,
+                    time2, time2,
+                    QLatin1String("8"),
+                    640, 480,
+                    QLatin1String("file:///t8.jpg"), QLatin1String("file:///8.jpg"));
+        database.addImage(
+                    image9, album3, user2,
+                    time1, time2,
+                    QLatin1String("9"),
+                    640, 480,
+                    QLatin1String("file:///t9.jpg"), QLatin1String("file:///9.jpg"));
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        bool ok = false;
+        QStringList imageIds;
+        imageIds = database.allImageIds(&ok);
+        QCOMPARE(ok, true);
+        QCOMPARE(imageIds.contains(image1), true);
+        QCOMPARE(imageIds.contains(image2), true);
+        QCOMPARE(imageIds.contains(image3), true);
+        QCOMPARE(imageIds.contains(image4), true);
+        QCOMPARE(imageIds.contains(image5), true);
+        QCOMPARE(imageIds.contains(image6), true);
+        QCOMPARE(imageIds.contains(image7), true);
+        QCOMPARE(imageIds.contains(image8), true);
+        QCOMPARE(imageIds.contains(image9), true);
+
+        imageIds = database.imageIds(album1, &ok);
+        QCOMPARE(ok, true);
+        QCOMPARE(imageIds.contains(image1), true);
+        QCOMPARE(imageIds.contains(image2), true);
+        QCOMPARE(imageIds.contains(image3), true);
+
+        imageIds = database.imageIds(album2, &ok);
+        QCOMPARE(ok, true);
+        QCOMPARE(imageIds.contains(image4), true);
+        QCOMPARE(imageIds.contains(image5), true);
+
+        imageIds = database.imageIds(album3, &ok);
+        QCOMPARE(ok, true);
+        QCOMPARE(imageIds.contains(image6), true);
+        QCOMPARE(imageIds.contains(image7), true);
+        QCOMPARE(imageIds.contains(image8), true);
+        QCOMPARE(imageIds.contains(image9), true);
+
+        FacebookImage::ConstPtr image;
+
+        image = database.image(image1);
+        QCOMPARE(image->fbImageId(), image1);
+        QCOMPARE(image->fbAlbumId(), album1);
+        QCOMPARE(image->fbUserId(), user1);
+        QCOMPARE(image->createdTime(), time1);
+        QCOMPARE(image->updatedTime(), time2);
+        QCOMPARE(image->imageName(), QLatin1String("1"));
+        QCOMPARE(image->width(), 640);
+        QCOMPARE(image->height(), 480);
+        QCOMPARE(image->thumbnailUrl(), QLatin1String("file:///t1.jpg"));
+        QCOMPARE(image->imageUrl(), QLatin1String("file:///1.jpg"));
+        QCOMPARE(image->imageFile(), QString());
+        QCOMPARE(image->thumbnailFile(), QString());
+
+        database.updateImageThumbnail(image1, QLatin1String("/t1.jpg"));
+        database.updateImageFile(image1, QLatin1String("/1.jpg"));
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        image = database.image(image1);
+        QCOMPARE(image->thumbnailFile(), QLatin1String("/t1.jpg"));
+        QCOMPARE(image->imageFile(), QLatin1String("/1.jpg"));
+
+        QList<FacebookImage::ConstPtr> images;
+
+        database.queryUserImages();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 9);
+
+        database.queryUserImages(user1);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 5);
+
+        database.queryUserImages(user2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 4);
+
+        database.queryAlbumImages(album1);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 3);
+
+        database.queryAlbumImages(album2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 2);
+
+        database.queryAlbumImages(album3);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 4);
+
+        database.removeImage(image7);
+        database.commit();
+
+        database.queryUserImages();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 8);
+
+        database.queryUserImages(user2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 3);
+
+        database.queryAlbumImages(album3);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 3);
+
+        database.removeAlbum(album2);
+        database.commit();
+
+        database.queryUserImages();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 6);
+
+        database.queryUserImages(user1);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 3);
+
+        database.queryAlbumImages(album2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 0);
+
+        database.removeUser(user2);
+        database.commit();
+
+        database.queryUserImages();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 3);
+
+        database.queryUserImages(user2);
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 0);
+
+        database.purgeAccount(1);
+        database.purgeAccount(2);
+        database.commit();
+
+        database.queryUserImages();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+        images = database.images();
+        QCOMPARE(images.count(), 0);
     }
 
     // TODO: more tests
@@ -128,9 +523,6 @@ private slots:
 
     void cleanupTestCase()
     {
-        delete fbDb;
-        delete checkDb;
-
         // Do the same cleanups
         QDir dir (PRIVILEGED_DATA_DIR);
         dir.removeRecursively();

--- a/tests/tst_facebookimage/tst_facebookimage.pro
+++ b/tests/tst_facebookimage/tst_facebookimage.pro
@@ -32,3 +32,5 @@ SOURCES +=  ../../src/lib/semaphore_p.cpp \
             ../../src/qml/facebook/facebookimagedownloader.cpp \
             main.cpp
 
+target.path = /opt/tests/libsocialcache
+INSTALLS += target

--- a/tests/tst_facebookpost/main.cpp
+++ b/tests/tst_facebookpost/main.cpp
@@ -1,0 +1,179 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd. <lucien.xu@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtTest/QTest>
+#include "facebookpostsdatabase.h"
+#include "socialsyncinterface.h"
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QStandardPaths>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+class FacebookPostsTest: public QObject
+{
+    Q_OBJECT
+private:
+
+private slots:
+    // Perform some cleanups
+    // we basically remove the whole ~/.local/share/system/privileged. While it is
+    // damaging on a device, on a desktop system it should not be much
+    // damaging.
+    void initTestCase()
+    {
+        QStandardPaths::enableTestMode(true);
+
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+    }
+
+    void posts()
+    {
+        QDateTime time1(QDate(2013, 1, 2), QTime(12, 34, 56));
+        QDateTime time2(QDate(2012, 3, 4), QTime(10, 11, 12));
+
+        const QString id1 = QLatin1String("id1");
+        const QString id2 = QLatin1String("id2");
+        const QString id3 = QLatin1String("id3");
+
+        const QString name1 = QLatin1String("name1");
+        const QString name2 = QLatin1String("name2");
+        const QString name3 = QLatin1String("name3");
+
+        const QString body1 = QLatin1String("body1");
+        const QString body2 = QLatin1String("body2");
+        const QString body3 = QLatin1String("body3");
+
+        const QString icon1 = QLatin1String("/icon.jpg");
+        const QString image1 = QLatin1String("http://example.com/image1.jpg");
+        const QString image2 = QLatin1String("http://example.com/image2.jpg");
+        const QString image3 = QLatin1String("http://example.com/image3.jpg");
+        const QString attachment1 = QLatin1String("attachment1");
+        const QString caption1 = QLatin1String("caption1");
+        const QString description1 = QLatin1String("description1");
+        const QString url1 = QLatin1String("http://example.com/attachment.png");
+        const QString client1 = QLatin1String("client1");
+
+        FacebookPostsDatabase database;
+
+        database.addFacebookPost(
+                    id1, name1, body1, time1, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >()
+                            << qMakePair(image1, SocialPostImage::Photo)
+                            << qMakePair(image2, SocialPostImage::Video),
+                    attachment1, caption1, description1, url1,
+                    true, true, client1, 1);
+        database.addFacebookPost(
+                    id1, name1, body1, time1, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >()
+                            << qMakePair(image1, SocialPostImage::Photo)
+                            << qMakePair(image2, SocialPostImage::Video),
+                    attachment1, caption1, description1, url1,
+                    true, true, client1, 2);
+        database.addFacebookPost(
+                    id2, name2, body2, time2, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >()
+                            << qMakePair(image3, SocialPostImage::Photo),
+                    QString(), QString(), QString(), QString(),
+                    false, false, client1, 1);
+        database.addFacebookPost(
+                    id3, name3, body3, time2, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >(),
+                    QString(), QString(), QString(), QString(),
+                    true, true, client1, 2);
+
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        database.refresh();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+
+        QList<SocialPost::ConstPtr> posts;
+
+        posts = database.posts();
+        QCOMPARE(posts.count(), 3);
+
+        SocialPost::ConstPtr post;
+        do {
+            post = posts.takeFirst();
+        } while (post->identifier() != id1 && posts.count() > 0);
+
+        QCOMPARE(post->identifier(), id1);
+        QCOMPARE(post->name(), name1);
+        QCOMPARE(post->body(), body1);
+        QCOMPARE(post->timestamp(), time1);
+        QCOMPARE(post->icon(), icon1);
+        QCOMPARE(post->images().count(), 2);
+        QCOMPARE(FacebookPostsDatabase::attachmentName(post), attachment1);
+        QCOMPARE(FacebookPostsDatabase::attachmentCaption(post), caption1);
+        QCOMPARE(FacebookPostsDatabase::attachmentDescription(post), description1);
+        QCOMPARE(FacebookPostsDatabase::attachmentUrl(post), url1);
+        QCOMPARE(FacebookPostsDatabase::allowLike(post), true);
+        QCOMPARE(FacebookPostsDatabase::allowComment(post), true);
+        QCOMPARE(FacebookPostsDatabase::clientId(post), client1);
+        QCOMPARE(post->accounts().count(), 2);
+
+        database.removePosts(2);
+        database.commit();
+        database.refresh();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+
+        posts = database.posts();
+        QCOMPARE(posts.count(), 2);
+
+        database.removePosts(1);
+        database.commit();
+        database.refresh();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+
+        posts = database.posts();
+        QCOMPARE(posts.count(), 0);
+    }
+
+    void cleanupTestCase()
+    {
+        // Do the same cleanups
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+
+    }
+};
+
+QTEST_MAIN(FacebookPostsTest)
+
+#include "main.moc"

--- a/tests/tst_facebookpost/tst_facebookpost.pro
+++ b/tests/tst_facebookpost/tst_facebookpost.pro
@@ -1,0 +1,26 @@
+include(../../common.pri)
+
+TEMPLATE = app
+TARGET = tst_facebookpost
+QT += network sql testlib
+
+DEFINES += NO_KEY_PROVIDER
+
+INCLUDEPATH += ../../src/lib/
+
+HEADERS +=  ../../src/lib/semaphore_p.h \
+            ../../src/lib/socialsyncinterface.h \
+            ../../src/lib/abstractsocialcachedatabase.h \
+            ../../src/lib/abstractsocialcachedatabase_p.h \
+            ../../src/lib/abstractsocialpostcachedatabase.h \
+            ../../src/lib/facebookpostsdatabase.h
+
+SOURCES +=  ../../src/lib/semaphore_p.cpp \
+            ../../src/lib/socialsyncinterface.cpp \
+            ../../src/lib/abstractsocialcachedatabase.cpp \
+            ../../src/lib/abstractsocialpostcachedatabase.cpp \
+            ../../src/lib/facebookpostsdatabase.cpp \
+            main.cpp
+
+target.path = /opt/tests/libsocialcache
+INSTALLS += target

--- a/tests/tst_socialnetworksync/main.cpp
+++ b/tests/tst_socialnetworksync/main.cpp
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd. <lucien.xu@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtTest/QTest>
+#include "socialnetworksyncdatabase.h"
+#include "socialsyncinterface.h"
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QStandardPaths>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+class SocialNetworkSyncTest: public QObject
+{
+    Q_OBJECT
+private:
+
+private slots:
+    // Perform some cleanups
+    // we basically remove the whole ~/.local/share/system/privileged. While it is
+    // damaging on a device, on a desktop system it should not be much
+    // damaging.
+    void initTestCase()
+    {
+        QStandardPaths::enableTestMode(true);
+
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+    }
+
+    void posts()
+    {
+        const QDateTime time1(QDate(2013, 1, 2), QTime(12, 34, 56));
+        const QDateTime time2(QDate(2012, 3, 4), QTime(10, 11, 12));
+
+        const QString service1 = QLatin1String("service1");
+        const QString service2 = QLatin1String("service2");
+        const QString data1 = QLatin1String("data1");
+        const QString data2 = QLatin1String("data2");
+
+        SocialNetworkSyncDatabase database;
+
+        database.addSyncTimestamp(service1, data1, 1, time1);
+        database.addSyncTimestamp(service1, data1, 1, time2);
+        database.addSyncTimestamp(service1, data1, 2, time1);
+        database.addSyncTimestamp(service1, data2, 1, time2);
+        database.addSyncTimestamp(service2, data1, 1, time1);
+        database.addSyncTimestamp(service2, data2, 2, time2);
+
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        QList<int> accounts;
+
+        accounts = database.syncedAccounts(service1, data1);
+        QCOMPARE(accounts.contains(1), true);
+        QCOMPARE(accounts.contains(2), true);
+
+        accounts = database.syncedAccounts(service1, data2);
+        QCOMPARE(accounts.contains(1), true);
+        QCOMPARE(accounts.contains(2), false);
+
+        accounts = database.syncedAccounts(service2, data2);
+        QCOMPARE(accounts.contains(1), false);
+        QCOMPARE(accounts.contains(2), true);
+
+        QCOMPARE(database.lastSyncTimestamp(service1, data1, 1), time2);
+        QCOMPARE(database.lastSyncTimestamp(service1, data1, 2), time1);
+        QCOMPARE(database.lastSyncTimestamp(service1, data2, 1), time2);
+    }
+
+    void cleanupTestCase()
+    {
+        // Do the same cleanups
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+
+    }
+};
+
+QTEST_MAIN(SocialNetworkSyncTest)
+
+#include "main.moc"

--- a/tests/tst_socialnetworksync/tst_socialnetworksync.pro
+++ b/tests/tst_socialnetworksync/tst_socialnetworksync.pro
@@ -1,0 +1,26 @@
+include(../../common.pri)
+
+TEMPLATE = app
+TARGET = tst_socialnetworksync
+QT += network sql testlib
+
+DEFINES += NO_KEY_PROVIDER
+
+INCLUDEPATH += ../../src/lib/
+
+HEADERS +=  ../../src/lib/semaphore_p.h \
+            ../../src/lib/socialsyncinterface.h \
+            ../../src/lib/abstractsocialcachedatabase.h \
+            ../../src/lib/abstractsocialcachedatabase_p.h \
+            ../../src/lib/abstractsocialpostcachedatabase.h \
+            ../../src/lib/socialnetworksyncdatabase.h
+
+SOURCES +=  ../../src/lib/semaphore_p.cpp \
+            ../../src/lib/socialsyncinterface.cpp \
+            ../../src/lib/abstractsocialcachedatabase.cpp \
+            ../../src/lib/abstractsocialpostcachedatabase.cpp \
+            ../../src/lib/socialnetworksyncdatabase.cpp \
+            main.cpp
+
+target.path = /opt/tests/libsocialcache
+INSTALLS += target

--- a/tests/tst_twitterpost/main.cpp
+++ b/tests/tst_twitterpost/main.cpp
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2013 Jolla Ltd. <lucien.xu@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtTest/QTest>
+#include "twitterpostsdatabase.h"
+#include "socialsyncinterface.h"
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QStandardPaths>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+class TwitterPostsTest: public QObject
+{
+    Q_OBJECT
+private:
+
+private slots:
+    // Perform some cleanups
+    // we basically remove the whole ~/.local/share/system/privileged. While it is
+    // damaging on a device, on a desktop system it should not be much
+    // damaging.
+    void initTestCase()
+    {
+        QStandardPaths::enableTestMode(true);
+
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+    }
+
+    void posts()
+    {
+        QDateTime time1(QDate(2013, 1, 2), QTime(12, 34, 56));
+        QDateTime time2(QDate(2012, 3, 4), QTime(10, 11, 12));
+
+        const QString id1 = QLatin1String("id1");
+        const QString id2 = QLatin1String("id2");
+        const QString id3 = QLatin1String("id3");
+
+        const QString name1 = QLatin1String("name1");
+        const QString name2 = QLatin1String("name2");
+        const QString name3 = QLatin1String("name3");
+
+        const QString body1 = QLatin1String("body1");
+        const QString body2 = QLatin1String("body2");
+        const QString body3 = QLatin1String("body3");
+
+        const QString icon1 = QLatin1String("/icon.jpg");
+        const QString image1 = QLatin1String("http://example.com/image1.jpg");
+        const QString image2 = QLatin1String("http://example.com/image2.jpg");
+        const QString image3 = QLatin1String("http://example.com/image3.jpg");
+        const QString screen1 = QLatin1String("screen1");
+        const QString retweeter1 = QLatin1String("retweeter1");
+        const QString key1 = QLatin1String("key1");
+        const QString secret1 = QLatin1String("secret1");
+
+        TwitterPostsDatabase database;
+
+        database.addTwitterPost(
+                    id1, name1, body1, time1, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >()
+                            << qMakePair(image1, SocialPostImage::Photo)
+                            << qMakePair(image2, SocialPostImage::Video),
+                    screen1, retweeter1, key1, secret1, 1);
+        database.addTwitterPost(
+                    id1, name1, body1, time1, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >()
+                            << qMakePair(image1, SocialPostImage::Photo)
+                            << qMakePair(image2, SocialPostImage::Video),
+                    screen1, retweeter1, key1, secret1, 2);
+        database.addTwitterPost(
+                    id2, name2, body2, time2, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >()
+                            << qMakePair(image3, SocialPostImage::Photo),
+                    screen1, retweeter1, key1, secret1, 1);
+        database.addTwitterPost(
+                    id3, name3, body3, time2, icon1,
+                    QList<QPair<QString, SocialPostImage::ImageType> >(),
+                    screen1, retweeter1, key1, secret1, 2);
+
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        database.refresh();
+        database.wait();
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+
+        QList<SocialPost::ConstPtr> posts;
+
+        posts = database.posts();
+        QCOMPARE(posts.count(), 3);
+
+        SocialPost::ConstPtr post;
+        do {
+            post = posts.takeFirst();
+        } while (post->identifier() != id1 && posts.count() > 0);
+
+        QCOMPARE(post->identifier(), id1);
+        QCOMPARE(post->name(), name1);
+        QCOMPARE(post->body(), body1);
+        QCOMPARE(post->timestamp(), time1);
+        QCOMPARE(post->icon(), icon1);
+        QCOMPARE(post->images().count(), 2);
+        QCOMPARE(TwitterPostsDatabase::screenName(post), screen1);
+        QCOMPARE(TwitterPostsDatabase::retweeter(post), retweeter1);
+        QCOMPARE(TwitterPostsDatabase::consumerKey(post), key1);
+        QCOMPARE(TwitterPostsDatabase::consumerSecret(post), secret1);
+        QCOMPARE(post->accounts().count(), 2);
+
+        database.removePosts(2);
+        database.commit();
+        database.refresh();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+
+        posts = database.posts();
+        QCOMPARE(posts.count(), 2);
+
+        database.removePosts(1);
+        database.commit();
+        database.refresh();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+        QCOMPARE(database.readStatus(), AbstractSocialCacheDatabase::Finished);
+
+        posts = database.posts();
+        QCOMPARE(posts.count(), 0);
+    }
+
+    void cleanupTestCase()
+    {
+        // Do the same cleanups
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+
+    }
+};
+
+QTEST_MAIN(TwitterPostsTest)
+
+#include "main.moc"

--- a/tests/tst_twitterpost/tst_twitterpost.pro
+++ b/tests/tst_twitterpost/tst_twitterpost.pro
@@ -1,0 +1,26 @@
+include(../../common.pri)
+
+TEMPLATE = app
+TARGET = tst_twitterpost
+QT += network sql testlib
+
+DEFINES += NO_KEY_PROVIDER
+
+INCLUDEPATH += ../../src/lib/
+
+HEADERS +=  ../../src/lib/semaphore_p.h \
+            ../../src/lib/socialsyncinterface.h \
+            ../../src/lib/abstractsocialcachedatabase.h \
+            ../../src/lib/abstractsocialcachedatabase_p.h \
+            ../../src/lib/abstractsocialpostcachedatabase.h \
+            ../../src/lib/twitterpostsdatabase.h
+
+SOURCES +=  ../../src/lib/semaphore_p.cpp \
+            ../../src/lib/socialsyncinterface.cpp \
+            ../../src/lib/abstractsocialcachedatabase.cpp \
+            ../../src/lib/abstractsocialpostcachedatabase.cpp \
+            ../../src/lib/twitterpostsdatabase.cpp \
+            main.cpp
+
+target.path = /opt/tests/libsocialcache
+INSTALLS += target


### PR DESCRIPTION
Hide most of the details of threading, database initialization and
locking away in AbstractSocialCacheDatabase and instead offer some
simple read and write virtuals within which the work can be done.

Simultaneously change from a model of dynamically generating queries for
each write to simply using static queries that are prepared once and
kept in a cache for re-use in subsequent writes.

Combined these changes reduce the total number threads used by
internally utilizing a thread pool, and cut down on time spent compiling
sql queries.
