### PR TITLE
[libsocialcache] Allow multiple models connected to one downloader

### DIFF
--- a/rpm/libsocialcache.spec
+++ b/rpm/libsocialcache.spec
@@ -1,6 +1,6 @@
 Name:       libsocialcache
 Summary:    A library that manages data from social networks
-Version:    0.0.14
+Version:    0.0.15
 Release:    1
 Group:      Applications/Multimedia
 License:    LGPLv2.1

--- a/src/lib/abstractimagedownloader.cpp
+++ b/src/lib/abstractimagedownloader.cpp
@@ -63,57 +63,35 @@ void AbstractImageDownloaderPrivate::manageStack()
     while (runningReplies.count() < MAX_SIMULTANEOUS_DOWNLOAD && !stack.isEmpty()) {
         // Create a reply to download the image
         ImageInfo *info = stack.takeLast();
-
         info->file.setFileName(q->outputFile(info->url, info->data));
-
         QDir parentDir = QFileInfo(info->file.fileName()).dir();
         if (!parentDir.exists()) {
             parentDir.mkpath(".");
         }
 
-        if (!info->file.open(QIODevice::ReadWrite)) {
-        } else if (QNetworkReply *reply = q->createReply(info->url, info->data)) {
-            reply->setReadBufferSize(250000);
-
-            QObject::connect(reply, &QIODevice::readyRead,
-                    q, &AbstractImageDownloader::readyRead);
+        if (QNetworkReply *reply = q->createReply(info->url, info->data)) {
             QObject::connect(reply, &QNetworkReply::finished,
                     q, &AbstractImageDownloader::slotFinished);
-
             runningReplies.insert(reply, info);
-
             return;
         }
-        qWarning() << Q_FUNC_INFO << "Failed to open file for write" << info->file.errorString();
 
         // emit signal.  Empty file signifies error.
         emit q->imageDownloaded(info->url, QString(), info->data);
-
         delete info;
     }
 }
 
 static void readData(ImageInfo *info, QNetworkReply *reply)
 {
-    qint64 size = info->file.size();
     qint64 bytesAvailable = reply->bytesAvailable();
-    if (bytesAvailable == 0)
+    if (bytesAvailable == 0) {
+        qWarning() << Q_FUNC_INFO << "No image data available";
         return;
-
-    info->file.resize(size + bytesAvailable);
-    if (uchar *fileData = info->file.map(size, bytesAvailable)) {
-        char *buffer = reinterpret_cast<char *>(fileData);
-        while (bytesAvailable > 0) {
-            qint64 bytesRead = reply->read(buffer, bytesAvailable);
-            bytesAvailable -= bytesRead;
-            buffer += bytesRead;
-
-            if (bytesRead <= 0) {
-                break;
-            }
-        }
-        info->file.unmap(fileData);
     }
+
+    QByteArray buf = reply->readAll();
+    info->file.write(buf);
 }
 
 void AbstractImageDownloader::readyRead()
@@ -145,18 +123,19 @@ void AbstractImageDownloader::slotFinished()
         return;
     }
 
-    readData(info, reply);
+    if (!info->file.open(QIODevice::ReadWrite)) {
+        qWarning() << Q_FUNC_INFO << "Failed to open file for write" << info->file.errorString();
+        emit imageDownloaded(info->url, QString(), info->data);
+        return;
+    }
 
     const QString fileName = info->file.fileName();
-
-
+    readData(info, reply);
     info->file.close();
 
     QImageReader reader(fileName);
     if (reader.canRead()) {
         dbQueueImage(info->url, info->data, fileName);
-
-        // Emit signal
         emit imageDownloaded(info->url, fileName, info->data);
     } else {
         emit imageDownloaded(info->url, QString(), info->data);

--- a/src/lib/facebookimagesdatabase.cpp
+++ b/src/lib/facebookimagesdatabase.cpp
@@ -963,6 +963,8 @@ bool FacebookImagesDatabase::write()
     qWarning() << "Queued users being saved:" << d->queue.insertUsers.count();
     qWarning() << "Queued albums being saved:" << d->queue.insertAlbums.count();
     qWarning() << "Queued images being saved:" << d->queue.insertImages.count();
+    qWarning() << "Queued thumbnail files being updated:" << d->queue.updateThumbnailFiles.count();
+    qWarning() << "Queued image files being updated:" << d->queue.updateImageFiles.count();
 
     const QList<int> purgeAccounts = d->queue.purgeAccounts;
 

--- a/src/qml/abstractsocialcachemodel.cpp
+++ b/src/qml/abstractsocialcachemodel.cpp
@@ -165,7 +165,6 @@ void AbstractSocialCacheModel::updateData(const SocialCacheModelData &data)
     Q_D(AbstractSocialCacheModel);
 
     const int count = d->m_data.count();
-
     synchronizeList(d, d->m_data, data);
 
     if (d->m_data.count() != count) {

--- a/src/qml/facebook/facebookimagecachemodel.h
+++ b/src/qml/facebook/facebookimagecachemodel.h
@@ -58,6 +58,8 @@ public:
     };
 
     explicit FacebookImageCacheModel(QObject *parent = 0);
+    ~FacebookImageCacheModel();
+
     QHash<int, QByteArray> roleNames() const;
 
     // properties
@@ -66,6 +68,9 @@ public:
 
     FacebookImageDownloader *downloader() const;
     void setDownloader(FacebookImageDownloader *downloader);
+
+    // from AbstractListModel
+    QVariant data(const QModelIndex &index, int role) const;
 
 public Q_SLOTS:
     void loadImages();
@@ -81,6 +86,7 @@ private Q_SLOTS:
 
 private:
     Q_DECLARE_PRIVATE(FacebookImageCacheModel)
+    friend class FacebookImageDownloader;
 };
 
 #endif // FACEBOOKIMAGECACHEMODEL_H

--- a/src/qml/facebook/facebookimagedownloader.h
+++ b/src/qml/facebook/facebookimagedownloader.h
@@ -24,6 +24,7 @@
 
 #include "abstractimagedownloader.h"
 
+class FacebookImageCacheModel;
 class FacebookImageDownloaderWorkerObject;
 class FacebookImageDownloaderPrivate;
 class FacebookImageDownloader : public AbstractImageDownloader
@@ -38,11 +39,18 @@ public:
     explicit FacebookImageDownloader(QObject *parent = 0);
     virtual ~FacebookImageDownloader();
 
+    // tracking object lifetime of models connected to this downloader.
+    void addModelToHash(FacebookImageCacheModel *model);
+    void removeModelFromHash(FacebookImageCacheModel *model);
+
 protected:
     QString outputFile(const QString &url, const QVariantMap &data) const;
 
     void dbQueueImage(const QString &url, const QVariantMap &data, const QString &file);
     void dbWrite();
+
+private Q_SLOTS:
+    void invokeSpecificModelCallback(const QString &url, const QString &path, const QVariantMap &metadata);
 
 private:
     Q_DECLARE_PRIVATE(FacebookImageDownloader)

--- a/src/qml/facebook/facebookimagedownloader_p.h
+++ b/src/qml/facebook/facebookimagedownloader_p.h
@@ -24,12 +24,13 @@
 #include <QtCore/QThread>
 #include <QtCore/QMutex>
 #include <QtCore/QWaitCondition>
+#include <QtCore/QSet>
 
 #include "abstractimagedownloader_p.h"
 #include "facebookimagedownloader.h"
 #include "facebookimagesdatabase.h"
 
-
+class FacebookImageCacheModel;
 class FacebookImageDownloaderPrivate: public AbstractImageDownloaderPrivate
 {
 public:
@@ -37,6 +38,7 @@ public:
     virtual ~FacebookImageDownloaderPrivate();
 
     FacebookImagesDatabase database;
+    QSet<FacebookImageCacheModel*> m_connectedModels;
 
 private:
     Q_DECLARE_PUBLIC(FacebookImageDownloader)


### PR DESCRIPTION
Previously, one image downloader could only be used with one model
at a time.  This commit fixes that issue.
It also removes usage of file.map() as it would warn about mapping
greater than filesize being unsupported on some platforms.
Finally, this commit doesn't download full images until they're
requested, to save data and reduce the time it takes to load
thumbnail files by a huge factor.
