### PR TITLE
[libsocialcache] Expose Twitter And Facebook model role ids to QML

### DIFF
--- a/src/qml/facebook/facebookpostsmodel.h
+++ b/src/qml/facebook/facebookpostsmodel.h
@@ -26,6 +26,7 @@ class FacebookPostsModelPrivate;
 class FacebookPostsModel: public AbstractSocialCacheModel
 {
     Q_OBJECT
+    Q_ENUMS(FacebookPostsRole)
 public:
     enum FacebookPostsRole {
         FacebookId = 0,

--- a/src/qml/twitter/twitterpostsmodel.h
+++ b/src/qml/twitter/twitterpostsmodel.h
@@ -26,6 +26,7 @@ class TwitterPostsModelPrivate;
 class TwitterPostsModel: public AbstractSocialCacheModel
 {
     Q_OBJECT
+    Q_ENUMS(TwitterPostsRole)
 public:
     enum TwitterPostsRole {
         TwitterId = 0,


### PR DESCRIPTION
Currently one needs to use hard coded role ids on client side when using AbstractSocialCacheModel::getField.
