### PR TITLE
[libsocialcache] Handle per-account profiles corectly in SyncHelper

### DIFF
--- a/src/qml/synchelper.h
+++ b/src/qml/synchelper.h
@@ -55,9 +55,12 @@ private slots:
                         int aStatusDetails);
 private:
     void checkCurrentRun();
+    void setLoading(bool loading);
+
     Buteo::SyncClientInterface *m_interface;
     SocialSyncInterface::SocialNetwork m_socialNetwork;
     SocialSyncInterface::DataType m_dataType;
+    QStringList m_activeSyncs;
     bool m_complete;
     bool m_loading;
 };


### PR DESCRIPTION
Handles per-account profile names correctly. Also aggregates status change signals and changes loading property only after all the syncs have finished.
