### PR TITLE
[libsocialcache] Remove error artifacts of image downloading

### DIFF
--- a/src/lib/abstractimagedownloader_p.h
+++ b/src/lib/abstractimagedownloader_p.h
@@ -41,11 +41,11 @@
 
 struct ImageInfo
 {
-    ImageInfo(const QString &url, const QVariantMap &data) : url(url), data(data) {}
+    ImageInfo(const QString &url, const QVariantMap &data) : url(url), requestsData(QList<QVariantMap>() << data) {}
 
     QString url;
-    QVariantMap data;
     QFile file;
+    QList<QVariantMap> requestsData;
 };
 
 


### PR DESCRIPTION
This commit ensures that any file data associated with an image
on disk is removed if the image download fails for any reason.
It also ensures that the appropriate signal is emitted in the case
where an image is queued for download twice.
