### PR TITLE
[libsocialcache] Automatically time out stuck image download requests

### DIFF
--- a/src/lib/abstractimagedownloader.h
+++ b/src/lib/abstractimagedownloader.h
@@ -71,6 +71,7 @@ protected:
 private Q_SLOTS:
     void readyRead();
     void slotFinished();
+    void timedOut();
 
 private:
     Q_DECLARE_PRIVATE(AbstractImageDownloader)

--- a/src/lib/abstractimagedownloader_p.h
+++ b/src/lib/abstractimagedownloader_p.h
@@ -37,6 +37,7 @@
 #include <QtCore/QMap>
 #include <QtCore/QPair>
 #include <QtCore/QVariantMap>
+#include <QtCore/QTimer>
 #include <QtNetwork/QNetworkAccessManager>
 
 struct ImageInfo
@@ -62,6 +63,7 @@ protected:
 private:
     void manageStack();
     QMap<QNetworkReply *, ImageInfo *> runningReplies;
+    QMap<QTimer *, QNetworkReply *> replyTimeouts;
     QList<ImageInfo *> stack;
     int loadedCount;
     Q_DECLARE_PUBLIC(AbstractImageDownloader)


### PR DESCRIPTION
This commit adds a default timeout to network requests in the image
downloader, to ensure that stuck requests cannot cause processes
which are waiting on the results to hang.
