### PR TITLE
[libsocialcache] Use Qt4 signal connection syntax for image replies

### DIFF
--- a/src/lib/abstractimagedownloader.cpp
+++ b/src/lib/abstractimagedownloader.cpp
@@ -78,8 +78,7 @@ void AbstractImageDownloaderPrivate::manageStack()
             timer->start();
             replyTimeouts.insert(timer, reply);
             reply->setProperty("timeoutTimer", QVariant::fromValue<QTimer*>(timer));
-            QObject::connect(reply, &QNetworkReply::finished,
-                    q, &AbstractImageDownloader::slotFinished);
+            QObject::connect(reply, SIGNAL(finished()), q, SLOT(slotFinished())); // For some reason, this fixes an issue with oopp sync plugins
             runningReplies.insert(reply, info);
         } else {
             // emit signal.  Empty file signifies error.


### PR DESCRIPTION
This commit changes the connection from the Qt5 syntax back to the
dynamic Qt4 syntax, as the Qt4 syntax fixes an issue whereby oopp
sync plugins couldn't download avatar images.
