### PR TITLE
[libsocialcache] Ensure queries in dropTables() succeed

### DIFF
--- a/src/lib/abstractsocialcachedatabase.cpp
+++ b/src/lib/abstractsocialcachedatabase.cpp
@@ -161,6 +161,7 @@ bool AbstractSocialCacheDatabasePrivate::initializeThreadData(ThreadData *thread
     }
 
     const int databaseVersion = query.value(0).toInt();
+    query.finish();
 
     if (databaseVersion < version) {
         createTables = true;


### PR DESCRIPTION
Finish user_version query before calling dropTables(), else db is still
locked when dropTables() tries to execute additional queries.
