### PR TITLE
[libsocialcache] Added profileDeleted signal to SyncHelper

### DIFF
--- a/src/qml/synchelper.h
+++ b/src/qml/synchelper.h
@@ -49,10 +49,13 @@ Q_SIGNALS:
     void socialNetworkChanged();
     void dataTypeChanged();
     void loadingChanged();
-    
+    void profileDeleted();
+
 private slots:
     void slotSyncStatus(const QString &aProfileId, int aStatus, const QString &aMessage,
                         int aStatusDetails);
+    void slotProfileChanged(QString aProfileId,int aChangeType, QString aChangedProfile);
+
 private:
     void checkCurrentRun();
     void setLoading(bool loading);


### PR DESCRIPTION
SyncHelper notifies when a profile is being synced and UI can then refresh
data after the sync is over. However, that mechanism cannot be used to
refresh data after a profile has been deleted. Added a new signal
for that purpose.
