### PR TITLE
[libsocialcache] Support UID+RecurrenceId kcal ids

### DIFF
--- a/rpm/libsocialcache.spec
+++ b/rpm/libsocialcache.spec
@@ -16,6 +16,7 @@ BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  pkgconfig(buteosyncfw5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
+BuildRequires:  pkgconfig(libkcalcoren-qt5)
 
 Requires:  qt5-plugin-sqldriver-sqlite
 

--- a/src/lib/caldavcalendardatabase.h
+++ b/src/lib/caldavcalendardatabase.h
@@ -21,6 +21,7 @@
 #define CALDAVCALENDARDATABASE_H
 
 #include "abstractsocialcachedatabase.h"
+#include "kcalid.h"
 
 #include <QtCore/QStringList>
 #include <QtCore/QHash>
@@ -33,13 +34,13 @@ public:
     explicit CalDavCalendarDatabase();
     ~CalDavCalendarDatabase();
 
-    QStringList additions(const QString &notebookUid, bool *ok);
-    QHash<QString, QString> modifications(const QString &notebookUid, bool *ok);
-    QStringList deletions(const QString &notebookUid, bool *ok);
+    QSet<KCalId> additions(const QString &notebookUid, bool *ok);
+    QHash<KCalId, QString> modifications(const QString &notebookUid, bool *ok);
+    QSet<KCalId> deletions(const QString &notebookUid, bool *ok);
 
-    void insertAdditions(const QString &notebookUid, const QStringList &incidenceUids);
-    void insertModifications(const QString &notebookUid, const QHash<QString, QString> &incidenceDetails);
-    void insertDeletions(const QString &notebookUid, const QStringList &incidenceUids);
+    void insertAdditions(const QString &notebookUid, const QSet<KCalId> &incidenceUids);
+    void insertModifications(const QString &notebookUid, const QHash<KCalId, QString> &incidenceDetails);
+    void insertDeletions(const QString &notebookUid, const QSet<KCalId> &incidenceIds);
     void removeIncidenceChangeEntriesOnly(const QString &notebookUid);
 
     QHash<QString, QString> eTags(const QString &notebookUid, bool *ok);

--- a/src/lib/caldavcalendardatabase.h
+++ b/src/lib/caldavcalendardatabase.h
@@ -34,6 +34,12 @@ public:
     explicit CalDavCalendarDatabase();
     ~CalDavCalendarDatabase();
 
+    QSet<QString> knownNotebookUids(bool *ok) const;
+    QString remoteCalendarPath(const QString &notebookUid, bool *ok) const;
+    void addRemoteCalendar(const QString &notebookUid, const QString &calendarPath);
+    bool needsCleanSync(const QString &notebookUid, bool *ok);
+    void setNeedsCleanSync(const QString &notebookUid, bool needsCleanSync);
+
     QSet<KCalId> additions(const QString &notebookUid, bool *ok);
     QHash<KCalId, QString> modifications(const QString &notebookUid, bool *ok);
     QSet<KCalId> deletions(const QString &notebookUid, bool *ok);

--- a/src/lib/kcalid.h
+++ b/src/lib/kcalid.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd. and/or its subsidiary(-ies).
+ * Contributors: Chris Adams <chris.adams@jollamobile.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <QtDebug>
+#include <QString>
+#include <KDateTime>
+#include <incidence.h>
+
+#ifndef KCALID_H
+#define KCALID_H
+
+// Every incidence in the m/kcal database is uniquely identified by
+// a combination of the series UID and the occurrence's recurrenceId
+// which identifies it within that series.
+
+class KCalId
+{
+public:
+    KCalId() {} // default ctor needed for QHash semantics.
+    explicit KCalId(const QString &incidenceUid, const KDateTime &incidenceRecurrenceId = KDateTime())
+        : uid(incidenceUid), recurrenceId(incidenceRecurrenceId) {}
+    explicit KCalId(const KCalCore::Incidence::Ptr &incidence)
+        : uid(incidence->uid()), recurrenceId(incidence->recurrenceId()) {}
+
+    QString toString() const
+    {
+        return QStringLiteral("%1,%2")
+               .arg(uid)
+               .arg(recurrenceId.isValid() ? recurrenceId.toString() : QString());
+    }
+    static KCalId fromString(const QString &str)
+    {
+        int commaIdx = str.lastIndexOf(',');
+        if (commaIdx <= 0) {
+            qWarning() << Q_FUNC_INFO << "invalid KCalId string:" << str;
+            return KCalId();
+        }
+
+        if (str.endsWith(',')) {
+            // this event doesn't contain a recurrence id.
+            return KCalId(str.mid(0, str.size() - 1), KDateTime());
+        }
+
+        // this event id consists of uid + recurrence id.
+        QString uid = str.mid(0, commaIdx);
+        QString rid = str.mid(commaIdx + 1);
+        return KCalId(uid, KDateTime::fromString(rid));
+    }
+
+    // data
+    QString uid;
+    KDateTime recurrenceId;
+};
+
+inline bool operator==(const KCalId &kcalId1, const KCalId &kcalId2)
+{
+    return (kcalId1.uid == kcalId2.uid) && (kcalId1.recurrenceId == kcalId2.recurrenceId);
+}
+
+inline uint qHash(const KCalId &kcalId)
+{
+    return qHash(kcalId.uid) ^ qHash(kcalId.recurrenceId.toTime_t());
+}
+
+Q_DECLARE_TYPEINFO(KCalId, Q_MOVABLE_TYPE);
+
+#endif // KCALID_H

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -1,7 +1,8 @@
 include(../../common.pri)
 
 TEMPLATE = lib
-CONFIG += qt create_prl no_install_prl create_pc
+CONFIG += qt create_prl no_install_prl create_pc link_pkgconfig
+PKGCONFIG += libkcalcoren-qt5
 QT += sql
 VERSION = 0.0.31
 
@@ -28,7 +29,8 @@ HEADERS = \
     facebooknotificationsdatabase.h \
     facebookpostsdatabase.h \
     twitterpostsdatabase.h \
-    caldavcalendardatabase.h
+    caldavcalendardatabase.h \
+    kcalid.h
 
 SOURCES = \
     semaphore_p.cpp \


### PR DESCRIPTION
This commit updates the caldav out-of-band storage database to use
composite ids (consisting of UID+RecurrenceId) instead of just
UID values, in order to support persistent occurrence exceptions.