### PR TITLE
[libsocialcache] Don't report images from disabled FB accounts. Contributes to MER#1126

### DIFF
--- a/rpm/libsocialcache.spec
+++ b/rpm/libsocialcache.spec
@@ -14,6 +14,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist
+BuildRequires:  pkgconfig(accounts-qt5)
 BuildRequires:  pkgconfig(buteosyncfw5)
 BuildRequires:  pkgconfig(libsailfishkeyprovider)
 

--- a/src/qml/qml.pro
+++ b/src/qml/qml.pro
@@ -18,7 +18,7 @@ CONFIG(nodeps):{
 DEFINES += NO_DEPS
 } else {
 CONFIG += link_pkgconfig
-PKGCONFIG += buteosyncfw5 libsailfishkeyprovider
+PKGCONFIG += buteosyncfw5 libsailfishkeyprovider accounts-qt5
 HEADERS += synchelper.h \
     keyproviderhelper.h
 SOURCES += synchelper.cpp \

--- a/tests/tst_facebookimage/tst_facebookimage.pro
+++ b/tests/tst_facebookimage/tst_facebookimage.pro
@@ -4,6 +4,9 @@ TEMPLATE = app
 TARGET = tst_facebookimage
 QT += network sql testlib
 
+CONFIG += link_pkgconfig
+PKGCONFIG += accounts-qt5
+
 DEFINES += NO_KEY_PROVIDER
 
 INCLUDEPATH += ../../src/lib/


### PR DESCRIPTION
Implements the short-term solution described in MER#1126 so that the
model now checks whether any enabled Facebook accounts exists on the
device at construction time.  If not, it doesn't report any data.

Contributes to MER#1126