### PR TITLE
[libsocialcache] Added SocialImageCache and related database.

### DIFF
--- a/src/lib/abstractimagedownloader_p.h
+++ b/src/lib/abstractimagedownloader_p.h
@@ -46,6 +46,7 @@ struct ImageInfo
 
     QString url;
     QFile file;
+    QString redirectUrl;
     QList<QVariantMap> requestsData;
 };
 

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -26,7 +26,8 @@ HEADERS = \
     facebooknotificationsdatabase.h \
     facebookpostsdatabase.h \
     twitterpostsdatabase.h \
-    twitternotificationsdatabase.h
+    twitternotificationsdatabase.h \
+    socialimagesdatabase.h
 
 SOURCES = \
     semaphore_p.cpp \
@@ -40,7 +41,8 @@ SOURCES = \
     facebooknotificationsdatabase.cpp \
     facebookpostsdatabase.cpp \
     twitterpostsdatabase.cpp \
-    twitternotificationsdatabase.cpp
+    twitternotificationsdatabase.cpp \
+    socialimagesdatabase.cpp
 
 headers.files = $$HEADERS
 headers.path = /usr/include/socialcache

--- a/src/lib/socialimagesdatabase.cpp
+++ b/src/lib/socialimagesdatabase.cpp
@@ -1,0 +1,448 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Antti Seppälä <antti.seppala@jollamobile.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "socialimagesdatabase.h"
+#include "abstractsocialcachedatabase.h"
+#include "socialsyncinterface.h"
+
+#include <QtSql/QSqlQuery>
+#include <QtSql/QSqlError>
+#include <QtCore/QFile>
+
+#include <QtDebug>
+
+static const char *DB_NAME = "socialimagecache.db";
+static const int VERSION = 2;
+
+struct SocialImagePrivate
+{
+    explicit SocialImagePrivate(int accountId,
+                                const QString &imageUrl,
+                                const QString &imageFile,
+                                const QDateTime &createdTime);
+    int accountId;
+    QString imageUrl;
+    QString imageFile;
+    QDateTime createdTime;
+};
+
+SocialImagePrivate::SocialImagePrivate(int accountId,
+                                       const QString &imageUrl,
+                                       const QString &imageFile,
+                                       const QDateTime &createdTime)
+    : accountId(accountId)
+    , imageUrl(imageUrl)
+    , imageFile(imageFile)
+    , createdTime(createdTime)
+{
+}
+
+SocialImage::SocialImage(int accountId,
+                         const QString &imageUrl,
+                         const QString &imageFile,
+                         const QDateTime &createdTime)
+    : d_ptr(new SocialImagePrivate(accountId, imageUrl,
+                                   imageFile, createdTime))
+{
+}
+
+SocialImage::~SocialImage()
+{
+}
+
+SocialImage::Ptr SocialImage::create(int accountId,
+                                     const QString & imageUrl,
+                                     const QString & imageFile,
+                                     const QDateTime &createdTime)
+{
+    return SocialImage::Ptr(new SocialImage(accountId, imageUrl,
+                                            imageFile, createdTime));
+}
+
+int SocialImage::accountId() const
+{
+    Q_D(const SocialImage);
+    return d->accountId;
+}
+
+QString SocialImage::imageUrl() const
+{
+    Q_D(const SocialImage);
+    return d->imageUrl;
+}
+
+QString SocialImage::imageFile() const
+{
+    Q_D(const SocialImage);
+    return d->imageFile;
+}
+
+QDateTime SocialImage::createdTime() const
+{
+    Q_D(const SocialImage);
+    return d->createdTime;
+}
+
+class SocialImagesDatabasePrivate: public AbstractSocialCacheDatabasePrivate
+{
+public:
+    explicit SocialImagesDatabasePrivate(SocialImagesDatabase *q);
+    ~SocialImagesDatabasePrivate();
+
+private:
+    Q_DECLARE_PUBLIC(SocialImagesDatabase)
+
+    static void clearCachedImages(QSqlQuery &query);
+
+    QList<SocialImage::ConstPtr> queryImages(int accountId,
+                                             const QDateTime &olderThan);
+
+    struct {
+        QList<int> purgeAccounts;
+        QStringList removeImages;
+        QMap<QString, SocialImage::ConstPtr> insertImages;
+    } queue;
+
+    struct {
+        int accountId;
+        QDateTime olderThan;
+        QList<SocialImage::ConstPtr> images;
+    } query;
+
+    struct {
+        QList<SocialImage::ConstPtr> images;
+    } result;
+
+    QSqlQuery m_singleImageQuery;
+};
+
+SocialImagesDatabasePrivate::SocialImagesDatabasePrivate(SocialImagesDatabase *q)
+    : AbstractSocialCacheDatabasePrivate(
+            q,
+            SocialSyncInterface::socialNetwork(SocialSyncInterface::Facebook),
+            SocialSyncInterface::dataType(SocialSyncInterface::Images),
+            QLatin1String(DB_NAME),
+            VERSION)
+{
+}
+
+SocialImagesDatabasePrivate::~SocialImagesDatabasePrivate()
+{
+}
+
+void SocialImagesDatabasePrivate::clearCachedImages(QSqlQuery &query)
+{
+    while (query.next()) {
+        QString image = query.value(0).toString();
+        if (!image.isEmpty()) {
+            QFile imageFile(image);
+            if (imageFile.exists()) {
+                imageFile.remove();
+            }
+        }
+    }
+}
+
+QList<SocialImage::ConstPtr> SocialImagesDatabasePrivate::queryImages(int accountId,
+                                                                      const QDateTime &olderThan)
+{
+    Q_Q(SocialImagesDatabase);
+
+    QList<SocialImage::ConstPtr> data;
+
+    QString queryString = QLatin1String("SELECT accountId, "
+                                        "imageUrl, imageFile, createdTime "
+                                        "FROM images "
+                                        "WHERE accountId = :accountId");
+
+    if (olderThan.isValid()) {
+        queryString.append(" AND createdTime < :createdTime");
+    }
+
+    QSqlQuery query = q->prepare(queryString);
+    query.bindValue(":accountId", accountId);
+
+    if (olderThan.isValid()) {
+        query.bindValue(":createdTime", olderThan.toTime_t());
+    }
+
+    if (!query.exec()) {
+        qWarning() << Q_FUNC_INFO << "Failed to query images:" << query.lastError().text();
+        return data;
+    }
+
+    while (query.next()) {
+        data.append(SocialImage::create(query.value(0).toInt(),                             // accountId
+                                        query.value(1).toString(),                          // imageUrl
+                                        query.value(2).toString(),                          // imageFile
+                                        QDateTime::fromTime_t(query.value(3).toUInt())));   // createdTime
+    }
+
+    return data;
+}
+
+bool operator==(const SocialImage::ConstPtr &image1,
+                const SocialImage::ConstPtr &image2)
+{
+    return image1->accountId() == image2->accountId()
+            && image1->imageUrl() == image2->imageUrl();
+}
+
+SocialImagesDatabase::SocialImagesDatabase()
+    : AbstractSocialCacheDatabase(*(new SocialImagesDatabasePrivate(this)))
+{
+}
+
+SocialImagesDatabase::~SocialImagesDatabase()
+{
+    wait();
+}
+
+void SocialImagesDatabase::purgeAccount(int accountId)
+{
+    Q_D(SocialImagesDatabase);
+    QMutexLocker locker(&d->mutex);
+
+    d->queue.purgeAccounts.append(accountId);
+}
+
+SocialImage::ConstPtr SocialImagesDatabase::image(const QString &imageUrl) const
+{
+    Q_D(const SocialImagesDatabase);
+
+    if (d->queue.insertImages.contains(imageUrl)) {
+        return d->queue.insertImages.value(imageUrl);
+    }
+
+    QSqlQuery query = prepare(
+                "SELECT accountId, "
+                "imageUrl, imageFile, createdTime "
+                "FROM images WHERE imageUrl = :imageUrl");
+    query.bindValue(":imageUrl", imageUrl);
+    if (!query.exec()) {
+        qWarning() << Q_FUNC_INFO << "Error reading from images table:" << query.lastError();
+        return SocialImage::Ptr();
+    }
+
+    // If we have the image, we have a result, otherwise we won't have the image
+    if (!query.next()) {
+        return SocialImage::Ptr();
+    }
+
+    return SocialImage::create(query.value(0).toInt(),                           // accountId
+                               query.value(1).toString(),                        // imageUrl
+                               query.value(2).toString(),                        // imageFile
+                               QDateTime::fromTime_t(query.value(3).toUInt()));  // createdTime
+}
+
+void SocialImagesDatabase::removeImage(const QString &imageUrl)
+{
+    Q_D(SocialImagesDatabase);
+    QMutexLocker locker(&d->mutex);
+
+    d->queue.insertImages.remove(imageUrl);
+    d->queue.removeImages.append(imageUrl);
+}
+
+void SocialImagesDatabase::removeImages(QList<SocialImage::ConstPtr> images)
+{
+    Q_D(SocialImagesDatabase);
+    QMutexLocker locker(&d->mutex);
+
+    foreach (SocialImage::ConstPtr image, images) {
+        d->queue.insertImages.remove(image->imageUrl());
+        d->queue.removeImages.append(image->imageUrl());
+    }
+}
+
+void SocialImagesDatabase::addImage(int accountId,
+                                    const QString & imageUrl,
+                                    const QString & imageFile,
+                                    const QDateTime &createdTime)
+{
+    Q_D(SocialImagesDatabase);
+    SocialImage::Ptr image = SocialImage::create(accountId, imageUrl, imageFile, createdTime);
+    QMutexLocker locker(&d->mutex);
+
+    d->queue.removeImages.removeAll(imageUrl);
+    d->queue.insertImages.insert(imageUrl, image);
+}
+
+void SocialImagesDatabase::commit()
+{
+    executeWrite();
+}
+
+QList<SocialImage::ConstPtr> SocialImagesDatabase::images() const
+{
+    return d_func()->result.images;
+}
+
+void SocialImagesDatabase::queryImages(int accountId,
+                                       const QDateTime &olderThan)
+{
+    Q_D(SocialImagesDatabase);
+    {
+        QMutexLocker locker(&d->mutex);
+        d->query.accountId = accountId;
+        d->query.olderThan = olderThan;
+    }
+    executeRead();
+}
+
+bool SocialImagesDatabase::read()
+{
+    Q_D(SocialImagesDatabase);
+    QMutexLocker locker(&d->mutex);
+
+    d->query.images = d->queryImages(d->query.accountId, d->query.olderThan);
+    return true;
+}
+
+void SocialImagesDatabase::readFinished()
+{
+    Q_D(SocialImagesDatabase);
+    {
+        QMutexLocker locker(&d->mutex);
+
+        d->result.images = d->query.images;
+        d->query.images.clear();
+    }
+    emit queryFinished();
+}
+
+bool SocialImagesDatabase::write()
+{
+    Q_D(SocialImagesDatabase);
+    QMutexLocker locker(&d->mutex);
+
+    qWarning() << "Queued images being saved:" << d->queue.insertImages.count();
+
+    const QList<int> purgeAccounts = d->queue.purgeAccounts;
+    const QStringList removeImages = d->queue.removeImages;
+
+    QList<SocialImage::ConstPtr> insertImages;
+    QMap<QString, SocialImage::ConstPtr>::const_iterator i = d->queue.insertImages.constBegin();
+    while (i != d->queue.insertImages.constEnd()) {
+        insertImages.append(i.value());
+        ++i;
+    }
+
+    d->queue.purgeAccounts.clear();
+    d->queue.removeImages.clear();
+    d->queue.insertImages.clear();
+
+    locker.unlock();
+
+    bool success = true;
+    QSqlQuery query;
+
+    if (!purgeAccounts.isEmpty()) {
+        QVariantList accountIds;
+        Q_FOREACH (int accountId, purgeAccounts) {
+            accountIds.append(accountId);
+        }
+
+        query = prepare(QStringLiteral(
+                    "SELECT imageFile FROM images "
+                    "WHERE accountId = :accountId"));
+        query.bindValue(QStringLiteral(":accountId"), accountIds);
+        if (!query.exec()) {
+            qWarning() << Q_FUNC_INFO << "Failed to exec images selection query:"
+                       << query.lastError().text();
+            success = false;
+        } else {
+            d->clearCachedImages(query);
+        }
+
+        query = prepare(QStringLiteral(
+                    "DELETE FROM images "
+                    "WHERE accountId = :accountId"));
+        query.bindValue(QStringLiteral(":accountId"), accountIds);
+        executeBatchSocialCacheQuery(query);
+    }
+
+    if (!removeImages.isEmpty()) {
+        QVariantList imageUrls;
+        foreach (const QString image, removeImages) {
+            imageUrls.append(image);
+        }
+
+        query = prepare(QStringLiteral(
+                    "DELETE FROM images "
+                    "WHERE imageUrl = :imageUrl"));
+        query.bindValue(QStringLiteral(":imageUrl"), imageUrls);
+        executeBatchSocialCacheQuery(query);
+    }
+
+    if (!insertImages.isEmpty()) {
+        QVariantList accountIds;
+        QVariantList imageUrls, imageFiles;
+        QVariantList createdTimes;
+
+        Q_FOREACH (const SocialImage::ConstPtr &image, insertImages) {
+            accountIds.append(image->accountId());
+            imageUrls.append(image->imageUrl());
+            imageFiles.append(image->imageFile());
+            createdTimes.append(image->createdTime().toTime_t());
+        }
+
+        query = prepare(QStringLiteral(
+                    "INSERT OR REPLACE INTO images ("
+                    " accountId, imageUrl, imageFile, createdTime) "
+                    "VALUES ("
+                    " :accountId, :imageUrl, :imageFile, :createdTime)"));
+        query.bindValue(QStringLiteral(":accountId"), accountIds);
+        query.bindValue(QStringLiteral(":imageUrl"), imageUrls);
+        query.bindValue(QStringLiteral(":imageFile"), imageFiles);
+        query.bindValue(QStringLiteral(":createdTime"), createdTimes);
+        executeBatchSocialCacheQuery(query);
+    }
+
+    return success;
+}
+
+bool SocialImagesDatabase::createTables(QSqlDatabase database) const
+{
+    // create the db table
+    QSqlQuery query(database);
+    query.prepare("CREATE TABLE IF NOT EXISTS images ("
+                  "accountId INTEGER,"
+                  "imageUrl TEXT,"
+                  "imageFile TEXT,"
+                  "createdTime INTEGER)");
+    if (!query.exec()) {
+        qWarning() << Q_FUNC_INFO << "Unable to create images table:" << query.lastError().text();
+        return false;
+    }
+
+    return true;
+}
+
+bool SocialImagesDatabase::dropTables(QSqlDatabase database) const
+{
+    QSqlQuery query(database);
+    query.prepare("DROP TABLE IF EXISTS images");
+    if (!query.exec()) {
+        qWarning() << Q_FUNC_INFO << "Failed to delete images table:" << query.lastError().text();
+        return false;
+    }
+
+    return true;
+}

--- a/src/lib/socialimagesdatabase.h
+++ b/src/lib/socialimagesdatabase.h
@@ -36,12 +36,14 @@ public:
     static SocialImage::Ptr create(int accountId,
                                    const QString &imageUrl,
                                    const QString &imageFile,
-                                   const QDateTime &createdTime);
+                                   const QDateTime &createdTime,
+                                   const QDateTime &expires);
 
     int accountId() const;
     QString imageUrl() const;
     QString imageFile() const;
     QDateTime createdTime() const;
+    QDateTime expires() const;
 
 protected:
     QScopedPointer<SocialImagePrivate> d_ptr;
@@ -51,7 +53,8 @@ private:
     explicit SocialImage(int accountId,
                          const QString & imageUrl,
                          const QString & imageFile,
-                         const QDateTime &createdTime);
+                         const QDateTime &createdTime,
+                         const QDateTime &expires);
 };
 
 bool operator==(const SocialImage::ConstPtr &image1, const SocialImage::ConstPtr &image2);
@@ -70,10 +73,12 @@ public:
     void addImage(int accountId,
                   const QString & imageUrl,
                   const QString & imageFile,
-                  const QDateTime &createdTime);
+                  const QDateTime &createdTime,
+                  const QDateTime &expires);
     void removeImage(const QString &imageUrl);
     void removeImages(QList<SocialImage::ConstPtr> images);
     void queryImages(int accountId, const QDateTime &olderThan = QDateTime());
+    void queryExpired(int accountId);
     QList<SocialImage::ConstPtr> images() const;
 
     void commit();

--- a/src/lib/socialimagesdatabase.h
+++ b/src/lib/socialimagesdatabase.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Antti Seppälä <antti.seppala@jollamobile.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef SOCIALIMAGESDATABASE_H
+#define SOCIALIMAGESDATABASE_H
+
+#include "abstractsocialcachedatabase_p.h"
+#include <QtCore/QDateTime>
+#include <QtCore/QStringList>
+
+class SocialImagePrivate;
+class SocialImage
+{
+public:
+    typedef QSharedPointer<SocialImage> Ptr;
+    typedef QSharedPointer<const SocialImage> ConstPtr;
+
+    virtual ~SocialImage();
+
+    static SocialImage::Ptr create(int accountId,
+                                   const QString &imageUrl,
+                                   const QString &imageFile,
+                                   const QDateTime &createdTime);
+
+    int accountId() const;
+    QString imageUrl() const;
+    QString imageFile() const;
+    QDateTime createdTime() const;
+
+protected:
+    QScopedPointer<SocialImagePrivate> d_ptr;
+
+private:
+    Q_DECLARE_PRIVATE(SocialImage)
+    explicit SocialImage(int accountId,
+                         const QString & imageUrl,
+                         const QString & imageFile,
+                         const QDateTime &createdTime);
+};
+
+bool operator==(const SocialImage::ConstPtr &image1, const SocialImage::ConstPtr &image2);
+
+class SocialImagesDatabasePrivate;
+class SocialImagesDatabase: public AbstractSocialCacheDatabase
+{
+    Q_OBJECT
+
+public:
+    explicit SocialImagesDatabase();
+    ~SocialImagesDatabase();
+
+    void purgeAccount(int accountId);
+    SocialImage::ConstPtr image(const QString &imageUrl) const;
+    void addImage(int accountId,
+                  const QString & imageUrl,
+                  const QString & imageFile,
+                  const QDateTime &createdTime);
+    void removeImage(const QString &imageUrl);
+    void removeImages(QList<SocialImage::ConstPtr> images);
+    void queryImages(int accountId, const QDateTime &olderThan = QDateTime());
+    QList<SocialImage::ConstPtr> images() const;
+
+    void commit();
+
+Q_SIGNALS:
+    void queryFinished();
+
+protected:
+    bool read();
+    void readFinished();
+
+    bool write();
+    bool createTables(QSqlDatabase database) const;
+    bool dropTables(QSqlDatabase database) const;
+
+
+private:
+    Q_DECLARE_PRIVATE(SocialImagesDatabase)
+};
+
+#endif // SOCIALIMAGESDATABASE_H

--- a/src/qml/generic/socialimagedownloader.cpp
+++ b/src/qml/generic/socialimagedownloader.cpp
@@ -1,0 +1,178 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Antti Seppälä <antti.seppala@jollamobile.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "socialimagedownloader.h"
+#include "socialimagedownloader_p.h"
+
+#include <QtCore/QStandardPaths>
+#include <QtGui/QGuiApplication>
+
+#include <QtDebug>
+#include <QUrl>
+#include <QFileInfo>
+
+SocialImageDownloaderPrivate::SocialImageDownloaderPrivate(SocialImageDownloader *q)
+    : AbstractImageDownloaderPrivate(q)
+{
+}
+
+SocialImageDownloaderPrivate::~SocialImageDownloaderPrivate()
+{
+    if (m_commitTimer.isActive()) {
+        m_db.commit();
+    }
+    m_db.wait();
+}
+
+SocialImageDownloader::SocialImageDownloader(QObject *parent) :
+    AbstractImageDownloader(*new SocialImageDownloaderPrivate(this), parent)
+{
+    Q_D(SocialImageDownloader);
+
+    connect(this, &AbstractImageDownloader::imageDownloaded,
+            this, &SocialImageDownloader::notifyImageCached);
+
+    // Commit timer will wait 30 seconds for additional addImage database calls to avoid
+    // unnecessary commits.
+    d->m_commitTimer.setInterval(30000);
+    d->m_commitTimer.setSingleShot(true);
+    connect(&d->m_commitTimer, SIGNAL(timeout()), this, SLOT(commitTimerTimeout()));
+}
+
+SocialImageDownloader::~SocialImageDownloader()
+{
+}
+
+void SocialImageDownloader::imageFile(const QString &imageUrl,
+                                      int accountId,
+                                      QObject *caller)
+{
+    Q_D(SocialImageDownloader);
+
+    if (imageUrl.isEmpty() || caller == 0) {
+        return;
+    }
+
+    QMutexLocker locker(&d->m_mutex);
+    QString recent = d->m_recentItems.value(imageUrl);
+    if (!recent.isEmpty()) {
+        QMetaObject::invokeMethod(caller, "imageCached", Q_ARG(QVariant, recent));
+        return;
+    } else {
+        SocialImage::ConstPtr image = d->m_db.image(imageUrl);
+        if (image != 0) {
+            d->m_recentItems.insert(imageUrl, image->imageFile());
+            QMetaObject::invokeMethod(caller, "imageCached", Q_ARG(QVariant, image->imageFile()));
+            return;
+        }
+    }
+
+    d->m_ongoingCalls.insert(imageUrl, QPointer<QObject>(caller));
+
+    QVariantMap data;
+    data.insert(QStringLiteral("accountId"), accountId);
+    queue(imageUrl, data);
+    return;
+}
+
+void SocialImageDownloader::removeFromRecentlyUsed(const QString &imageUrl)
+{
+    Q_D(SocialImageDownloader);
+
+    QMutexLocker locker(&d->m_mutex);
+    d->m_recentItems.remove(imageUrl);
+}
+
+void SocialImageDownloader::notifyImageCached(const QString &imageUrl,
+                                              const QString &imageFile,
+                                              const QVariantMap &metadata)
+{
+    Q_D(SocialImageDownloader);
+
+    QMutexLocker locker(&d->m_mutex);
+
+    QList< QPointer<QObject> > ongoingCalls = d->m_ongoingCalls.values(imageUrl);
+
+    if (imageFile.isEmpty()) {
+        qWarning() << "SocialImageDownloader: failed to download " << imageFile;
+        for (int i = 0; i < ongoingCalls.count(); ++i) {
+           if (ongoingCalls.at(i) != 0) {
+               QMetaObject::invokeMethod(ongoingCalls.at(i).data(), "downloadError");
+           }
+        }
+        d->m_ongoingCalls.remove(imageUrl);
+        return;
+    }
+
+    d->m_recentItems.insert(imageUrl, imageFile);
+    int accountId = metadata.value(QStringLiteral("accountId")).toInt();
+    d->m_db.addImage(accountId, imageUrl, imageFile, QDateTime::currentDateTime());
+    // We assume that there will consecutive addImage calls. Wait suitable
+    // time before commiting.
+    if (d->m_commitTimer.isActive()) {
+        d->m_commitTimer.stop();
+    }
+    d->m_commitTimer.start();
+
+    for (int i = 0; i < ongoingCalls.count(); ++i) {
+       if (ongoingCalls.at(i) != 0) {
+           QMetaObject::invokeMethod(ongoingCalls.at(i).data(), "imageCached", Q_ARG(QVariant, imageFile));
+       }
+    }
+    d->m_ongoingCalls.remove(imageUrl);
+}
+
+QString SocialImageDownloader::outputFile(const QString &url,
+                                           const QVariantMap &data) const
+{
+    Q_UNUSED(data);
+
+    if (url.isEmpty()) {
+        return QString();
+    }
+
+    QUrl name(url);
+    QString ending;
+    QStringList parts = name.fileName().split(".");
+    if (parts.count() > 1) {
+        ending = parts.last();
+    }
+    if (ending.isEmpty()) {
+        // assume jpg
+        ending = "jpg";
+    }
+
+    QCryptographicHash hash (QCryptographicHash::Md5);
+    hash.addData(url.toUtf8());
+    QByteArray hashedIdentifier = hash.result().toHex();
+
+    QString path = QStringLiteral("%1%2/%3/%4/%5.%6").arg(PRIVILEGED_DATA_DIR,
+                                                  SocialSyncInterface::dataType(SocialSyncInterface::Images),
+                                                  "cache",
+                                                  QChar(hashedIdentifier.at(0)),
+                                                  hashedIdentifier,
+                                                  ending);
+    return path;
+}
+
+void SocialImageDownloader::commitTimerTimeout()
+{
+    Q_D(SocialImageDownloader);
+    d->m_db.commit();
+}

--- a/src/qml/generic/socialimagedownloader.cpp
+++ b/src/qml/generic/socialimagedownloader.cpp
@@ -61,7 +61,8 @@ SocialImageDownloader::~SocialImageDownloader()
 
 void SocialImageDownloader::imageFile(const QString &imageUrl,
                                       int accountId,
-                                      QObject *caller)
+                                      QObject *caller,
+                                      int expiresInDays)
 {
     Q_D(SocialImageDownloader);
 
@@ -87,6 +88,7 @@ void SocialImageDownloader::imageFile(const QString &imageUrl,
 
     QVariantMap data;
     data.insert(QStringLiteral("accountId"), accountId);
+    data.insert(QStringLiteral("expiresInDays"), expiresInDays);
     queue(imageUrl, data);
     return;
 }
@@ -122,7 +124,10 @@ void SocialImageDownloader::notifyImageCached(const QString &imageUrl,
 
     d->m_recentItems.insert(imageUrl, imageFile);
     int accountId = metadata.value(QStringLiteral("accountId")).toInt();
-    d->m_db.addImage(accountId, imageUrl, imageFile, QDateTime::currentDateTime());
+    int expiresInDays = metadata.value(QStringLiteral("expiresInDays")).toInt();
+    QDateTime currentTime(QDateTime::currentDateTime());
+    d->m_db.addImage(accountId, imageUrl, imageFile, currentTime,
+                     currentTime.addDays(expiresInDays));
     // We assume that there will consecutive addImage calls. Wait suitable
     // time before commiting.
     if (d->m_commitTimer.isActive()) {

--- a/src/qml/generic/socialimagedownloader.h
+++ b/src/qml/generic/socialimagedownloader.h
@@ -34,7 +34,7 @@ public:
     explicit SocialImageDownloader(QObject *parent = 0);
     virtual ~SocialImageDownloader();
 
-    Q_INVOKABLE void imageFile(const QString &imageUrl, int accountId, QObject *caller);
+    Q_INVOKABLE void imageFile(const QString &imageUrl, int accountId, QObject *caller, int expiresInDays = 30);
     Q_INVOKABLE void removeFromRecentlyUsed(const QString &imageUrl);
 
 protected:

--- a/src/qml/generic/socialimagedownloader.h
+++ b/src/qml/generic/socialimagedownloader.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Antti Seppälä <antti.seppala@jollamobile.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef SOCIALIMAGEDOWNLOADER_H
+#define SOCIALIMAGEDOWNLOADER_H
+
+#include <QtCore/QObject>
+
+#include "abstractimagedownloader.h"
+
+class SocialImageCacheModel;
+class SocialImageDownloaderPrivate;
+class SocialImageDownloader : public AbstractImageDownloader
+{
+    Q_OBJECT
+
+public:
+    explicit SocialImageDownloader(QObject *parent = 0);
+    virtual ~SocialImageDownloader();
+
+    Q_INVOKABLE void imageFile(const QString &imageUrl, int accountId, QObject *caller);
+    Q_INVOKABLE void removeFromRecentlyUsed(const QString &imageUrl);
+
+protected:
+    QString outputFile(const QString &url, const QVariantMap &data) const;
+
+private Q_SLOTS:
+    void notifyImageCached(const QString &url, const QString &path, const QVariantMap &metadata);
+    void commitTimerTimeout();
+
+private:
+    Q_DECLARE_PRIVATE(SocialImageDownloader)
+};
+
+#endif // SOCIALIMAGEDOWNLOADER_H

--- a/src/qml/generic/socialimagedownloader_p.h
+++ b/src/qml/generic/socialimagedownloader_p.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd.
+ * Contact: Antti Seppälä <antti.seppala@jollamobile.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef SOCIALIMAGEDOWNLOADER_P_H
+#define SOCIALIMAGEDOWNLOADER_P_H
+
+#include "abstractimagedownloader_p.h"
+#include "socialimagedownloader.h"
+#include "socialimagesdatabase.h"
+
+#include <QPointer>
+
+class SocialImageDownloaderPrivate : public AbstractImageDownloaderPrivate
+{
+public:
+    explicit SocialImageDownloaderPrivate(SocialImageDownloader *q);
+    virtual ~SocialImageDownloaderPrivate();
+
+    SocialImagesDatabase m_db;
+    QTimer m_commitTimer;
+    QMap<QString, QString> m_recentItems;
+    QMultiMap<QString, QPointer<QObject> > m_ongoingCalls;
+    QMutex m_mutex;
+
+private:
+    Q_DECLARE_PUBLIC(SocialImageDownloader)
+};
+
+#endif // SOCIALIMAGEDOWNLOADER_P_H

--- a/src/qml/plugin.cpp
+++ b/src/qml/plugin.cpp
@@ -29,6 +29,8 @@
 #include "facebook/facebookpostsmodel.h"
 #include "facebook/facebooknotificationsmodel.h"
 #include "twitter/twitterpostsmodel.h"
+#include "generic/socialimagedownloader.h"
+
 
 #ifndef NO_DEPS
 #include "synchelper.h"
@@ -94,8 +96,7 @@ public:
 
         qmlRegisterType<TwitterPostsModel>(uri, 1, 0, "TwitterPostsModel");
 
-
-
+        qmlRegisterType<SocialImageDownloader>(uri, 1, 0, "SocialImageCache");
 
 #ifndef NO_DEPS
         qmlRegisterUncreatableType<SocialSyncInterface>(uri, 1, 0, "SocialSync",

--- a/src/qml/qml.pro
+++ b/src/qml/qml.pro
@@ -37,7 +37,9 @@ HEADERS += \
     facebook/facebookimagedownloaderconstants_p.h \
     facebook/facebookpostsmodel.h \
     facebook/facebooknotificationsmodel.h \
-    twitter/twitterpostsmodel.h
+    twitter/twitterpostsmodel.h \
+    generic/socialimagedownloader.h \
+    generic/socialimagedownloader_p.h
 
 SOURCES += plugin.cpp \
     abstractsocialcachemodel.cpp \
@@ -45,7 +47,8 @@ SOURCES += plugin.cpp \
     facebook/facebookimagedownloader.cpp \
     facebook/facebookpostsmodel.cpp \
     facebook/facebooknotificationsmodel.cpp \
-    twitter/twitterpostsmodel.cpp
+    twitter/twitterpostsmodel.cpp \
+    generic/socialimagedownloader.cpp
 
 OTHER_FILES += qmldir
 import.files = qmldir

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -6,5 +6,5 @@ SUBDIRS = \
         tst_facebookpost \
         tst_facebooknotification \
         tst_socialnetworksync \
-        tst_twitterpost
-
+        tst_twitterpost \
+        tst_socialimage

--- a/tests/tst_socialimage/main.cpp
+++ b/tests/tst_socialimage/main.cpp
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2015 Jolla Ltd. <antti.seppala@jollamobile.com>
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include <QtTest/QTest>
+#include "socialimagesdatabase.h"
+#include "socialsyncinterface.h"
+#include <QtCore/QDebug>
+#include <QtCore/QDir>
+#include <QtCore/QStandardPaths>
+#include <QtSql/QSqlDatabase>
+#include <QtSql/QSqlQuery>
+
+class SocialImageTest: public QObject
+{
+    Q_OBJECT
+
+private:
+    SocialImage::ConstPtr imageFromList(QList<SocialImage::ConstPtr> &images,
+                                         const QString &imageUrl)
+    {
+        foreach (SocialImage::ConstPtr image, images) {
+            if (image->imageUrl() == imageUrl) {
+                return image;
+            }
+        }
+
+        return SocialImage::ConstPtr();
+    }
+
+private slots:
+    // Perform some cleanups
+    // we basically remove the whole ~/.local/share/system/privileged. While it is
+    // damaging on a device, on a desktop system it should not be much
+    // damaging.
+    void initTestCase()
+    {
+        QStandardPaths::enableTestMode(true);
+
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+    }
+
+    void images()
+    {
+        const int account1 = 1;
+        const int account2 = 2;
+
+        QDateTime time1 (QDate(2013, 1, 2), QTime(12, 34, 56));
+        QDateTime time2 (QDate(2015, 1, 2), QTime(12, 43, 56));
+
+        SocialImagesDatabase database;
+
+        // test insert images
+        database.addImage(
+                    account1,
+                    QLatin1String("file:///t1.jpg"), QLatin1String("file:///1.jpg"),
+                    time1);
+        database.addImage(
+                    account1,
+                    QLatin1String("file:///t2.jpg"), QLatin1String("file:///2.jpg"),
+                    time2);
+        database.addImage(
+                    account1,
+                    QLatin1String("file:///t3.jpg"), QLatin1String("file:///3.jpg"),
+                    time2);
+        database.addImage(
+                    account2,
+                    QLatin1String("file:///t4.jpg"), QLatin1String("file:///4.jpg"),
+                    time2);
+
+        // check that the images are availbale from insert queue
+        // already before commit
+        SocialImage::ConstPtr image = database.image(QLatin1String("file:///t1.jpg"));
+        QVERIFY(image != 0);
+        QVERIFY(image != 0);
+        QCOMPARE(image->accountId(), account1);
+        QCOMPARE(image->imageUrl(), QString("file:///t1.jpg"));
+        QCOMPARE(image->imageFile(), QString("file:///1.jpg"));
+        QCOMPARE(image->createdTime(), time1);
+
+        // then commit and test the rest
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        database.queryImages(account1);
+        database.wait();
+        QList<SocialImage::ConstPtr> images = database.images();
+        QCOMPARE(images.count(), 3);
+
+        image = imageFromList(images, "file:///t1.jpg");
+        QVERIFY(image != 0);
+        QCOMPARE(image->accountId(), account1);
+        QCOMPARE(image->imageUrl(), QString("file:///t1.jpg"));
+        QCOMPARE(image->imageFile(), QString("file:///1.jpg"));
+        QCOMPARE(image->createdTime(), time1);
+
+        image = imageFromList(images, "file:///t2.jpg");
+        QVERIFY(image != 0);
+        QCOMPARE(image->accountId(), account1);
+        QCOMPARE(image->imageUrl(), QString("file:///t2.jpg"));
+        QCOMPARE(image->imageFile(), QString("file:///2.jpg"));
+        QCOMPARE(image->createdTime(), time2);
+
+        image = imageFromList(images, "file:///t3.jpg");
+        QVERIFY(image != 0);
+        QCOMPARE(image->accountId(), account1);
+        QCOMPARE(image->imageUrl(), QString("file:///t3.jpg"));
+        QCOMPARE(image->imageFile(), QString("file:///3.jpg"));
+        QCOMPARE(image->createdTime(), time2);
+
+        database.queryImages(account2);
+        database.wait();
+        images = database.images();
+        QCOMPARE(images.count(), 1);
+
+        image = imageFromList(images, "file:///t4.jpg");
+        QVERIFY(image != 0);
+        QCOMPARE(image->accountId(), account2);
+        QCOMPARE(image->imageUrl(), QString("file:///t4.jpg"));
+        QCOMPARE(image->imageFile(), QString("file:///4.jpg"));
+        QCOMPARE(image->createdTime(), time2);
+
+        // test olderThan
+        database.queryImages(account1, QDateTime(QDate(2014, 1, 2), QTime(12, 43, 56)));
+        database.wait();
+        images = database.images();
+        QCOMPARE(images.count(), 1);
+
+        image = imageFromList(images, "file:///t1.jpg");
+        QVERIFY(image != 0);
+        QCOMPARE(image->accountId(), account1);
+        QCOMPARE(image->imageUrl(), QString("file:///t1.jpg"));
+        QCOMPARE(image->imageFile(), QString("file:///1.jpg"));
+        QCOMPARE(image->createdTime(), time1);
+
+        // test remove image
+        database.removeImage("file:///t1.jpg");
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        database.queryImages(account1);
+        database.wait();
+        images = database.images();
+        QCOMPARE(images.count(), 2);
+        image = imageFromList(images, "file:///t1.jpg");
+        QVERIFY(image == 0);
+
+        image = imageFromList(images, "file:///t2.jpg");
+        QVERIFY(image != 0);
+        QList<SocialImage::ConstPtr> removeImages;
+        removeImages.append(image);
+        database.removeImages(removeImages);
+        database.commit();
+        database.wait();
+
+        database.queryImages(account1);
+        database.wait();
+        images = database.images();
+        QCOMPARE(images.count(), 1);
+        image = imageFromList(images, "file:///t2.jpg");
+        QVERIFY(image == 0);
+
+        // test purge accounts
+        database.purgeAccount(1);
+        database.commit();
+        database.wait();
+        QCOMPARE(database.writeStatus(), AbstractSocialCacheDatabase::Finished);
+
+        database.queryImages(account1);
+        database.wait();
+        images = database.images();
+        QCOMPARE(images.count(), 0);
+
+        database.queryImages(account2);
+        database.wait();
+        images = database.images();
+        QCOMPARE(images.count(), 1);
+
+        image = imageFromList(images, "file:///t4.jpg");
+        QVERIFY(image != 0);
+        QCOMPARE(image->accountId(), account2);
+        QCOMPARE(image->imageUrl(), QString("file:///t4.jpg"));
+        QCOMPARE(image->imageFile(), QString("file:///4.jpg"));
+        QCOMPARE(image->createdTime(), time2);
+    }
+
+    void cleanupTestCase()
+    {
+        // Do the same cleanups
+        QDir dir (PRIVILEGED_DATA_DIR);
+        dir.removeRecursively();
+
+    }
+};
+
+QTEST_MAIN(SocialImageTest)
+
+#include "main.moc"

--- a/tests/tst_socialimage/tst_socialimage.pro
+++ b/tests/tst_socialimage/tst_socialimage.pro
@@ -1,0 +1,31 @@
+include(../../common.pri)
+
+TEMPLATE = app
+TARGET = tst_socialimage
+QT += network sql testlib
+
+DEFINES += NO_KEY_PROVIDER
+
+INCLUDEPATH += ../../src/lib/
+INCLUDEPATH += ../../src/qml/
+
+HEADERS +=  ../../src/lib/semaphore_p.h \
+            ../../src/lib/socialsyncinterface.h \
+            ../../src/lib/abstractsocialcachedatabase.h \
+            ../../src/lib/abstractsocialcachedatabase_p.h \
+            ../../src/lib/socialimagesdatabase.h \
+            ../../src/lib/abstractimagedownloader.h \
+            ../../src/lib/abstractimagedownloader_p.h \
+            ../../src/qml/abstractsocialcachemodel.h \
+            ../../src/qml/abstractsocialcachemodel_p.h
+
+SOURCES +=  ../../src/lib/semaphore_p.cpp \
+            ../../src/lib/socialsyncinterface.cpp \
+            ../../src/lib/abstractsocialcachedatabase.cpp \
+            ../../src/lib/socialimagesdatabase.cpp \
+            ../../src/lib/abstractimagedownloader.cpp \
+            ../../src/qml/abstractsocialcachemodel.cpp \
+            main.cpp
+
+target.path = /opt/tests/libsocialcache
+INSTALLS += target


### PR DESCRIPTION
Implemented mechanism for caching social media images, such as avatars and images which appear in feeds.
It consists of three classes:

SocialImageDatabase:
  - A database which binds together accountId, image source and cached path.

SocialImageCache:
  - A worker class which loads to-be-cached images on the background and is able to return path to cached version of an image.

SocialMediaCacheItem:

  - A QML-accessible item, which provides path to cached image when image source is given to it.

The idea is that instead of providing original source to QML Image, we pass imageFile property from SocialImageCacheItem to it and
everything else happens on the background. If an account is deleted, buteo purges cached images belogin to that account and images older than given threshold.  

Also modified AbstractImageDownloader to handle URL redirection (Facebook avatars are provided that way). 