### PR TITLE
[libsocialcache] Handle identifier strings correctly. Contributes to …

### DIFF
--- a/src/lib/abstractsocialpostcachedatabase.cpp
+++ b/src/lib/abstractsocialpostcachedatabase.cpp
@@ -347,7 +347,7 @@ bool AbstractSocialPostCacheDatabase::read()
                 "SELECT identifier, name, body, timestamp "
                 "FROM posts");
     if (!d->accountIdFilter.isEmpty()) {
-        postQueryString += " WHERE identifier IN (" + filteredPostIds.join(',') + ')';
+        postQueryString += " WHERE identifier IN (\"" + filteredPostIds.join("\",\"") + "\")";
     }
     postQueryString += " ORDER BY timestamp DESC";
 


### PR DESCRIPTION
…MER#1268

Identifiers are strings. Earlier version worked as long as they only contained digits but broke VK branch where indentifier is formed as "userId_postIndex".