### PR TITLE
[libsocialcache] Fixed profile matching. Fixes JB#32898

### DIFF
--- a/src/qml/synchelper.cpp
+++ b/src/qml/synchelper.cpp
@@ -99,7 +99,7 @@ void SyncHelper::slotSyncStatus(const QString &aProfileId, int aStatus,
     Q_UNUSED(aMessage)
     Q_UNUSED(aStatusDetails)
 
-    if (profileIdMatches(aProfileId)) {
+    if (!profileIdMatches(aProfileId)) {
         return;
     }
 


### PR DESCRIPTION
Missing not operator caused sync helper to report ongoing sync for
all profiles not curently syncing